### PR TITLE
fix dipendenze e script di init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,13 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-long_description = '\n\n'.join([
-    open('README.rst').read(),
-    open('CONTRIBUTORS.rst').read(),
-    open('CHANGES.rst').read(),
-])
+long_description = '\n\n'.join(
+    [
+        open('README.rst').read(),
+        open('CONTRIBUTORS.rst').read(),
+        open('CHANGES.rst').read(),
+    ]
+)
 
 
 setup(
@@ -54,6 +56,9 @@ setup(
         'plone.api>=1.8.4',
         'plone.restapi',
         'plone.app.dexterity',
+        'collective.venue',
+        'plone.formwidget.geolocation',
+        'collective.folderishtypes[dexterity]',
     ],
     extras_require={
         'test': [
@@ -64,7 +69,7 @@ setup(
             'plone.testing>=5.0.0',
             'plone.app.contenttypes',
             'plone.app.robotframework[debug]',
-        ],
+        ]
     },
     entry_points="""
     [z3c.autoinclude.plugin]

--- a/src/design/plone/contenttypes/setuphandlers.py
+++ b/src/design/plone/contenttypes/setuphandlers.py
@@ -1,59 +1,24 @@
 # -*- coding: utf-8 -*-
-from Products.CMFPlone.interfaces import (
-    INonInstallable,
-    ISelectableConstrainTypes,
-)
 from design.plone.contenttypes.utils import folderSubstructureGenerator
-from zope.interface import implementer
 from plone import api
+from Products.CMFPlone.interfaces import INonInstallable
+from zope.interface import implementer
 
 
 @implementer(INonInstallable)
 class HiddenProfiles(object):
     def getNonInstallableProfiles(self):
         """Hide uninstall profile from site-creation and quickinstaller."""
-        return [
-            "design.plone.contenttypes:uninstall",
-        ]
+        return ["design.plone.contenttypes:uninstall"]
 
 
 def post_install(context):
     """Post install script"""
-    # Do something at the end of the installation of this package.
     portal = api.portal.get()
-
-    # if not api.content.find(portal_type="AmministrazioneFolder"):
-    # amministrazione = api.content.create(
-    #     container=portal,
-    #     type="Folder",
-    #     id="amministrazione",
-    #     title="Amministrazione",
-    # )
-
-    # api.content.transition(obj=amministrazione, transition="publish")
-
-    # also generate amministrazione substructure like this, removing
-    # custom folder cts?
     folderSubstructureGenerator(portal, "Amministrazione")
     folderSubstructureGenerator(portal, "Servizi")
     folderSubstructureGenerator(portal, "Novità")
     folderSubstructureGenerator(portal, "Documenti e dati")
-    # news = api.content.create(
-    #     container=portal, type="NewsFolder", id="novità", title="Novità",
-    # )
-    # api.content.transition(obj=news, transition="publish")
-
-    # servizi = api.content.create(
-    #     container=portal, type="Folder", id="servizi", title="Servizi",
-    # )
-    # serviziConstraints = ISelectableConstrainTypes(servizi)
-    # serviziConstraints.setConstrainTypesMode(1)
-    # serviziConstraints.setLocallyAllowedTypes(("Servizio",))
-
-    # tolgo la possibilità di aggiungere l'oggetto ovunque
-    # pt = portal.portal_types
-    # Amministrazione = pt["AmministrazioneFolder"]
-    # Amministrazione.global_allow = False
 
 
 def uninstall(context):

--- a/src/design/plone/contenttypes/utils.py
+++ b/src/design/plone/contenttypes/utils.py
@@ -1,6 +1,5 @@
 from plone import api
 from Products.CMFPlone.interfaces import ISelectableConstrainTypes
-import re
 
 TASSONOMIA_SERVIZI = [
     "Anagrafe e stato civile",
@@ -38,7 +37,7 @@ TASSONOMIA_NEWS = ["Notizie", "Comunicati", "Eventi"]
 def folderSubstructureGenerator(container, title):
 
     tree_root = api.content.create(
-        container=container, type="Document", id=title.lower(), title=title,
+        container=container, type="Document", title=title
     )
     api.content.transition(obj=tree_root, transition="publish")
     if title == "Servizi":
@@ -46,13 +45,8 @@ def folderSubstructureGenerator(container, title):
         tree_rootConstraints.setConstrainTypesMode(1)
         tree_rootConstraints.setLocallyAllowedTypes(("Document",))
         for ts in TASSONOMIA_SERVIZI:
-            _ = ts.lower()
-            _id = re.sub(r"[^a-z\s]", "", _)
             folder = api.content.create(
-                container=tree_root,
-                type="Document",
-                id=re.sub(" ", "-", _id),
-                title=ts,
+                container=tree_root, type="Document", title=ts
             )
 
             folderConstraints = ISelectableConstrainTypes(folder)
@@ -65,13 +59,8 @@ def folderSubstructureGenerator(container, title):
         tree_rootConstraints.setLocallyAllowedTypes(("Document",))
 
         for td in TASSONOMIA_DOCUMENTI:
-            _ = td.lower()
-            _id = re.sub(r"[^a-z\s]", "", _)
             folder = api.content.create(
-                container=tree_root,
-                type="Document",
-                id=re.sub(" ", "-", _id),
-                title=td,
+                container=tree_root, type="Document", title=td
             )
 
             folderConstraints = ISelectableConstrainTypes(folder)
@@ -86,13 +75,8 @@ def folderSubstructureGenerator(container, title):
         tree_rootConstraints.setConstrainTypesMode(1)
         tree_rootConstraints.setLocallyAllowedTypes(("Document",))
         for tn in TASSONOMIA_NEWS:
-            _ = tn.lower()
-            _id = re.sub(r"[^a-z\s]", "", _)
             folder = api.content.create(
-                container=tree_root,
-                type="Document",
-                id=re.sub(" ", "-", _id),
-                title=tn,
+                container=tree_root, type="Document", title=tn
             )
 
             folderConstraints = ISelectableConstrainTypes(folder)
@@ -106,11 +90,11 @@ def folderSubstructureGenerator(container, title):
         tree_rootConstraints = ISelectableConstrainTypes(tree_root)
         tree_rootConstraints.setConstrainTypesMode(1)
         tree_rootConstraints.setLocallyAllowedTypes(
-            ("PersoneFolder", "UnitaOrganizzativaFolder", "LuoghiFolder",)
+            ("PersoneFolder", "UnitaOrganizzativaFolder", "LuoghiFolder")
         )
 
         api.content.create(
-            type="PersoneFolder", title="Politici", container=tree_root,
+            type="PersoneFolder", title="Politici", container=tree_root
         )
         api.content.create(
             type="PersoneFolder",
@@ -138,5 +122,5 @@ def folderSubstructureGenerator(container, title):
             container=tree_root,
         )
         api.content.create(
-            type="LuoghiFolder", title="Luoghi", container=tree_root,
+            type="LuoghiFolder", title="Luoghi", container=tree_root
         )


### PR DESCRIPTION
Note per @deodorhunter per i prossimi lavori ;)

- Se un pacchetto ha delle dipendenze con altri, allora bisogna segnarle nel setup.py
- Lo script di creazione dei contenuti generava gli id a mano e male..plone.api fa tutto da solo e bene, basta passargli il titolo