### PR TITLE
Bug10396 typo social media

### DIFF
--- a/src/design/plone/contenttypes/controlpanels/configure.zcml
+++ b/src/design/plone/contenttypes/controlpanels/configure.zcml
@@ -4,6 +4,8 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="design.plone.contenttypes">
 
+  <include package="Products.CMFCore" file="permissions.zcml" />
+
   <browser:page
       name="design-plone-vocabularies"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/src/design/plone/contenttypes/locales/it/LC_MESSAGES/plone.po
+++ b/src/design/plone/contenttypes/locales/it/LC_MESSAGES/plone.po
@@ -1,3 +1,21 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2020-03-23 14:51+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+
 #: CMFPlone/interfaces/controlpanel.py:1432
 msgid "To identify things like Twitter Cards. Do not include the \"@\" prefix character."
-msgstr "Per identificare cose come le Twitter Card. Non includere come prefisso il carattere \"@\"
+msgstr "Per identificare cose come le Twitter Card. Non includere il carattere \"@\" come prefisso."
+

--- a/src/design/plone/contenttypes/locales/it/LC_MESSAGES/plone.po
+++ b/src/design/plone/contenttypes/locales/it/LC_MESSAGES/plone.po
@@ -1,0 +1,3 @@
+#: CMFPlone/interfaces/controlpanel.py:1432
+msgid "To identify things like Twitter Cards. Do not include the \"@\" prefix character."
+msgstr "Per identificare cose come le Twitter Card. Non includere come prefisso il carattere \"@\"


### PR DESCRIPTION
Risolve il bug delle traduzioni del pannello di controllo social media

AGGIUNGERE NEL BUILDOUT
```
zcml = 
    design.plone.contenttypes
```