### PR TITLE
customize base serializer to add a meta type with the current object type

### DIFF
--- a/src/design/plone/contenttypes/__init__.py
+++ b/src/design/plone/contenttypes/__init__.py
@@ -2,5 +2,8 @@
 """Init and utils."""
 from zope.i18nmessageid import MessageFactory
 
+_ = MessageFactory("design.plone.contenttypes")
 
-_ = MessageFactory('design.plone.contenttypes')
+# need to be the last thing we import: in the patch we import the message
+# factory above
+from design.plone.contenttypes import patches  # noqa

--- a/src/design/plone/contenttypes/patches/__init__.py
+++ b/src/design/plone/contenttypes/patches/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from design.plone.contenttypes.patches.baseserializer import (
+    patch_base_serializer,
+)
+import logging
+
+logger = logging.getLogger("design.plone.contenttypes.patches")
+
+logger.info(
+    "Patching plone.restapi.serializer.dxcontent.SerializeToJson._call__"
+)
+patch_base_serializer()

--- a/src/design/plone/contenttypes/patches/baseserializer.py
+++ b/src/design/plone/contenttypes/patches/baseserializer.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+We need a solution like that because for some different reasons:
+ * we have to customize both SerializeToJson and SerializeFolderToJson
+ * If we override SerializeToJson adding this base design_italia_meta_type
+   information, we need to override SerializeFolderToJson copying the whole
+   code otherwise it will use the code from original SerializeToJson due to
+   inheritance
+ * Using a monkey patch is the easiest way to include future changes on base
+   SerializeToJson and SerializeFolderToJson classes
+"""
+
+from plone.restapi.serializer.dxcontent import SerializeToJson
+from plone import api
+from zope.i18n import translate
+from design.plone.contenttypes import _
+
+original_serialize_to_json__call__ = SerializeToJson.__call__
+
+
+def design_italia_serialize_to_json_call(
+    self, version=None, include_items=True
+):
+    ttool = api.portal.get_tool("portal_types")
+    result = original_serialize_to_json__call__(
+        self, version=None, include_items=True
+    )
+    if self.context.portal_type == "News Item":
+        result["design_italia_meta_type"] = translate(
+            self.context.tipologia_notizia,
+            domain=_._domain,
+            context=self.request,
+        )
+    else:
+        result["design_italia_meta_type"] = translate(
+            ttool[self.context.portal_type].Title(), context=self.request
+        )
+
+    return result
+
+
+def patch_base_serializer():
+    SerializeToJson.__call__ = design_italia_serialize_to_json_call

--- a/src/design/plone/contenttypes/tests/test_base_serializer.py
+++ b/src/design/plone/contenttypes/tests/test_base_serializer.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+"""Setup tests for this package."""
+from plone import api
+from plone.app.testing import (
+    SITE_OWNER_NAME,
+    SITE_OWNER_PASSWORD,
+    TEST_USER_ID,
+    setRoles,
+)
+from plone.restapi.testing import RelativeSession
+from transaction import commit
+from design.plone.contenttypes.testing import (
+    DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING,
+)
+import unittest
+
+
+class TestBaseSerializer(unittest.TestCase):
+    """Test that design.plone.contenttypes is properly installed."""
+
+    layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({"Accept": "application/json"})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+        self.news = api.content.create(
+            container=self.portal, type="News Item", title="TestNews"
+        )
+        self.news.tipologia_notizia = "Comunicati stampa"
+        self.service = api.content.create(
+            container=self.portal, type="Servizio", title="TestService"
+        )
+        commit()
+
+    def tearDown(self):
+        self.api_session.close()
+
+    def test_design_italia_meta_type_with_news(self):
+        """
+        News should return the news type (tipologia_notizia field)
+        Other types shoule return their own portal_type.
+        """
+        response_news = self.api_session.get(
+            self.news.absolute_url() + "?fullobjects",
+        )
+        self.assertTrue(
+            response_news.json()["design_italia_meta_type"]
+            == "Comunicati stampa"
+        )
+
+    def test_design_italia_meta_type_with_type_different_from_news(self):
+        """
+        News should return the news type (tipologia_notizia field)
+        Other types shoule return their own portal_type.
+        """
+        response_service = self.api_session.get(
+            self.service.absolute_url() + "?fullobjects",
+        )
+
+        self.assertTrue(
+            response_service.json()["design_italia_meta_type"] == "Servizio"
+        )


### PR DESCRIPTION
we need it 'cause we could have a page type != from portal_type, eg. news are "comunicati stampa" or "notizie" or "avvisi"