### PR TITLE
Riorganizzazione campi

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-2)
   - [Servizio](#servizio)
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-3)
-  - [Unità Organizzativa](#unit%C3%A0-organizzativa)
+  - [Unità Organizzativa](#unità-organizzativa)
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-4)
 - [Gestione vocabolari](#gestione-vocabolari)
 - [Installazione](#installazione)
@@ -40,34 +40,6 @@ gestione di un sito Agid con Plone e Volto.
 
 ## Elenco tipi implementati
 
-- [ ] **Dataset**
-
-  - [ ] Definizione campi
-  - [ ] Ordine campi
-  - [ ] Indicizzazione testo
-  - [ ] Vista su Volto completata
-
-- [ ] **Documento**
-
-  - [ ] Definizione campi
-  - [ ] Ordine campi
-  - [ ] Indicizzazione testo
-  - [ ] Vista su Volto completata
-
-- [ ] **Documento Personale**
-
-  - [ ] Definizione campi
-  - [ ] Ordine campi
-  - [ ] Indicizzazione testo
-  - [ ] Vista su Volto completata
-
-- [ ] **Evento**
-
-  - [x] Definizione campi
-  - [ ] Ordine campi
-  - [ ] Indicizzazione testo
-  - [ ] Vista su Volto completata
-
 - [ ] **Collegamento**
 
   - [x] Definizione campi
@@ -76,17 +48,52 @@ gestione di un sito Agid con Plone e Volto.
   - [x] Vista su Volto completata
   - [ ] Selezione link interno
 
+
+- [ ] **Dataset**
+
+  - [ ] Definizione campi
+  - [ ] Ordine campi
+  - [ ] Ordine fieldsets
+  - [ ] Indicizzazione testo
+  - [ ] Vista su Volto completata
+
+- [ ] **Documento**
+
+  - [ ] Definizione campi
+  - [ ] Ordine campi
+  - [ ] Ordine fieldsets
+  - [ ] Indicizzazione testo
+  - [ ] Vista su Volto completata
+
+- [ ] **Documento Personale**
+
+  - [ ] Definizione campi
+  - [ ] Ordine campi
+  - [ ] Ordine fieldsets
+  - [ ] Indicizzazione testo
+  - [ ] Vista su Volto completata
+
+- [ ] **Evento**
+
+  - [x] Definizione campi
+  - [ ] Ordine campi
+  - [ ] Ordine fieldsets
+  - [ ] Indicizzazione testo
+  - [ ] Vista su Volto completata
+
 - [ ] **Messaggio**
 
   - [ ] Definizione campi
   - [ ] Ordine campi
+  - [ ] Ordine fieldsets
   - [ ] Indicizzazione testo
   - [ ] Vista su Volto completata
 
-- [x] **Notizia**
+- [ ] **Notizia**
 
   - [x] Definizione campi
   - [x] Ordine campi
+  - [ ] Ordine fieldsets
   - [x] Indicizzazione testo
   - [x] Vista su Volto completata
 
@@ -95,6 +102,7 @@ gestione di un sito Agid con Plone e Volto.
   - [x] Definizione campi
   - [x] Abilitare behavior collective.address.address
   - [ ] Ordine campi
+  - [ ] Ordine fieldsets
   - [x] Indicizzazione testo
   - [ ] Vista su Volto completata
   - [ ] gestione di "è sede di" 
@@ -103,6 +111,7 @@ gestione di un sito Agid con Plone e Volto.
 
   - [ ] Definizione campi
   - [ ] Ordine campi
+  - [ ] Ordine fieldsets
   - [x] Indicizzazione testo
   - [ ] Vista su Volto completata
 
@@ -110,6 +119,7 @@ gestione di un sito Agid con Plone e Volto.
 
   - [x] Definizione campi
   - [ ] Ordine campi
+  - [ ] Ordine fieldsets
   - [x] Indicizzazione testo
   - [x] Vista su Volto completata
 
@@ -117,6 +127,7 @@ gestione di un sito Agid con Plone e Volto.
 
   - [ ] Definizione campi
   - [ ] Ordine campi
+  - [ ] Ordine fieldsets
   - [ ] Indicizzazione testo
   - [ ] Vista su Volto completata
 
@@ -124,13 +135,15 @@ gestione di un sito Agid con Plone e Volto.
 
   - [ ] Definizione campi
   - [ ] Ordine campi
+  - [ ] Ordine fieldsets
   - [ ] Indicizzazione testo
   - [ ] Vista su Volto completata
 
-- [ ] **Servizio**
+- [x] **Servizio**
 
   - [x] Definizione campi
-  - [ ] Ordine campi
+  - [x] Ordine campi
+  - [x] Ordine fieldsets
   - [x] Indicizzazione testo
   - [x] Vista su Volto completata
 
@@ -138,6 +151,7 @@ gestione di un sito Agid con Plone e Volto.
 
   - [x] Definizione campi
   - [x] Ordine campi
+  - [x] Ordine fieldsets
   - [x] Indicizzazione testo
   - [x] Vista su Volto completata
 
@@ -200,7 +214,7 @@ dei blocchi anche per le pagine argomento.
 
 - blocchi Volto
 - unita_amministrativa_responsabile
-- box_aiuto
+- ulteriori_informazioni
 
 ## Persona
 
@@ -225,7 +239,7 @@ dei blocchi anche per le pagine argomento.
 - come_si_fa
 - cosa_si_ottiene
 - cosa_serve
-- box_aiuto
+- ulteriori_informazioni
 - tassonomia_argomenti
 - copertura_geografica
 - costi

--- a/base.cfg
+++ b/base.cfg
@@ -35,6 +35,19 @@ eggs =
     design.plone.contenttypes [test]
     Products.PDBDebugMode
 
+zcml-additional =
+  <configure xmlns="http://namespaces.zope.org/zope"
+             xmlns:plone="http://namespaces.plone.org/plone">
+  <plone:CORSPolicy
+    allow_origin="http://localhost:3000,http://127.0.0.1:3000"
+    allow_methods="DELETE,GET,OPTIONS,PATCH,POST,PUT"
+    allow_credentials="true"
+    expose_headers="Content-Length,X-My-Header"
+    allow_headers="Accept,Authorization,Content-Type,X-Custom-Header,Origin"
+    max_age="3600"
+    />
+  </configure>
+
 [code-analysis]
 recipe = plone.recipe.codeanalysis
 directory = ${buildout:directory}/src

--- a/src/design/plone/contenttypes/behaviors/additional_help_infos.py
+++ b/src/design/plone/contenttypes/behaviors/additional_help_infos.py
@@ -5,7 +5,6 @@ from plone.app.textfield import RichText
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.autoform import directives as form
 from zope.component import adapter
 from zope.interface import provider, implementer
 
@@ -36,22 +35,6 @@ class IAdditionalHelpInfos(model.Schema):
 @implementer(IAdditionalHelpInfos)
 @adapter(IDexterityContent)
 class AdditionalHelpInfos(object):
-    """
-    """
-
-    def __init__(self, context):
-        self.context = context
-
-
-@provider(IFormFieldProvider)
-class IAdditionalHelpInfosEvento(IAdditionalHelpInfos):
-
-    form.order_before(ulteriori_informazioni="IEventContact.event_url")
-
-
-@implementer(IAdditionalHelpInfosEvento)
-@adapter(IDexterityContent)
-class AdditionalHelpInfosEvento(object):
     """
     """
 

--- a/src/design/plone/contenttypes/behaviors/additional_help_infos.py
+++ b/src/design/plone/contenttypes/behaviors/additional_help_infos.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collective import dexteritytextindexer
 from design.plone.contenttypes import _
 from plone.app.textfield import RichText
 from plone.autoform.interfaces import IFormFieldProvider
@@ -18,11 +19,18 @@ class IAdditionalHelpInfos(model.Schema):
         title=_(u"ulteriori_informazioni", default=u"Ulteriori informazioni"),
         description=_(
             "ulteriori_informazioni_help",
-            default="Ulteriori informazioni non contemplate"
-            " dai campi precedenti.",
+            default="Ulteriori informazioni non contemplate" " dai campi precedenti.",
         ),
         required=False,
     )
+
+    model.fieldset(
+        "informazioni",
+        label=_("informazioni_label", default=u"Ulteriori informazioni"),
+        fields=["ulteriori_informazioni"],
+    )
+
+    dexteritytextindexer.searchable("ulteriori_informazioni")
 
 
 @implementer(IAdditionalHelpInfos)
@@ -38,11 +46,6 @@ class AdditionalHelpInfos(object):
 @provider(IFormFieldProvider)
 class IAdditionalHelpInfosEvento(IAdditionalHelpInfos):
 
-    model.fieldset(
-        "informazioni",
-        label=_("informazioni_label", default=u"Informazioni"),
-        fields=["ulteriori_informazioni"],
-    )
     form.order_before(ulteriori_informazioni="IEventContact.event_url")
 
 

--- a/src/design/plone/contenttypes/behaviors/argomenti.py
+++ b/src/design/plone/contenttypes/behaviors/argomenti.py
@@ -24,8 +24,7 @@ class IArgomenti(model.Schema):
             " contenuto.",
         ),
         value_type=RelationChoice(
-            title=_(u"Argomenti correlati"),
-            vocabulary="plone.app.vocabularies.Catalog",
+            title=_(u"Argomenti correlati"), vocabulary="plone.app.vocabularies.Catalog"
         ),
         required=False,
         default=[],
@@ -42,7 +41,7 @@ class IArgomenti(model.Schema):
 
     model.fieldset(
         "correlati",
-        label=_("correlati_label", default=u"Correlati"),
+        label=_("correlati_label", default="Contenuti collegati"),
         fields=["tassonomia_argomenti"],
     )
 

--- a/src/design/plone/contenttypes/behaviors/argomenti.py
+++ b/src/design/plone/contenttypes/behaviors/argomenti.py
@@ -39,11 +39,7 @@ class IArgomenti(model.Schema):
         },
     )
 
-    model.fieldset(
-        "correlati",
-        label=_("correlati_label", default="Contenuti collegati"),
-        fields=["tassonomia_argomenti"],
-    )
+    model.fieldset("categorization", fields=["tassonomia_argomenti"])
 
     dexteritytextindexer.searchable("tassonomia_argomenti")
 
@@ -51,26 +47,6 @@ class IArgomenti(model.Schema):
 @implementer(IArgomenti)
 @adapter(IDexterityContent)
 class Argomenti(object):
-    """
-    """
-
-    def __init__(self, context):
-        self.context = context
-
-
-@provider(IFormFieldProvider)
-class IArgomentiEvento(IArgomenti):
-    model.fieldset(
-        "categorization",
-        label=_(u"label_schema_categorization", default=u"Categorization"),
-        fields=["tassonomia_argomenti"],
-    )
-    form.order_before(tassonomia_argomenti="IDublinCore.subjects")
-
-
-@implementer(IArgomentiEvento)
-@adapter(IDexterityContent)
-class ArgomentiEvento(object):
     """
     """
 

--- a/src/design/plone/contenttypes/behaviors/configure.zcml
+++ b/src/design/plone/contenttypes/behaviors/configure.zcml
@@ -101,15 +101,6 @@
       for="plone.dexterity.interfaces.IDexterityContent"
       marker=".additional_help_infos.IAdditionalHelpInfos"
       />
-    <plone:behavior
-      title="Ulteriori campi aiuto testuali"
-      name="design.plone.contenttypes.behavior.additional_help_infos_evento"
-      description=""
-      provides=".additional_help_infos.IAdditionalHelpInfosEvento"
-      factory=".additional_help_infos.AdditionalHelpInfosEvento"
-      for="plone.app.contenttypes.interfaces.IEvent"
-      marker=".additional_help_infos.IAdditionalHelpInfosEvento"
-      />
 
     <plone:behavior
       title="Descrizione estesa"

--- a/src/design/plone/contenttypes/behaviors/configure.zcml
+++ b/src/design/plone/contenttypes/behaviors/configure.zcml
@@ -44,15 +44,6 @@
       marker=".argomenti.IArgomenti"
       />
     <plone:behavior
-      title="Argomenti"
-      name="design.plone.contenttypes.behavior.argomenti_evento"
-      description="Tassonomia argomenti"
-      provides=".argomenti.IArgomentiEvento"
-      factory=".argomenti.ArgomentiEvento"
-      for="plone.dexterity.interfaces.IDexterityContent"
-      marker=".argomenti.IArgomentiEvento"
-      />
-    <plone:behavior
       title="Luoghi correlati"
       name="design.plone.contenttypes.behavior.luoghi_correlati"
       description=""

--- a/src/design/plone/contenttypes/behaviors/dataset_correlati.py
+++ b/src/design/plone/contenttypes/behaviors/dataset_correlati.py
@@ -37,7 +37,7 @@ class IDatasetCorrelati(model.Schema):
 
     model.fieldset(
         "correlati",
-        label=_("correlati_label", default=u"Correlati"),
+        label=_("correlati_label", default="Contenuti collegati"),
         fields=["dataset_correlati"],
     )
 

--- a/src/design/plone/contenttypes/behaviors/evento.py
+++ b/src/design/plone/contenttypes/behaviors/evento.py
@@ -28,9 +28,7 @@ class IEvento(model.Schema):
     # )
 
     descrizione_destinatari = RichText(
-        title=_(
-            u"descrizione_destinatari", default=u"Descrizione destinatari"
-        ),
+        title=_(u"descrizione_destinatari", default=u"Descrizione destinatari"),
         required=False,
         description=_(
             "descrizione_destinatari_help",
@@ -56,10 +54,7 @@ class IEvento(model.Schema):
         "persone_amministrazione",
         RelatedItemsFieldWidget,
         vocabulary="plone.app.vocabularies.Catalog",
-        pattern_options={
-            "maximumSelectionSize": 10,
-            "selectableTypes": ["Persona"],
-        },
+        pattern_options={"maximumSelectionSize": 10, "selectableTypes": ["Persona"]},
     )
 
     # model.fieldset(
@@ -87,8 +82,7 @@ class IEvento(model.Schema):
         title=_(u"orari", default=u"Informazioni sugli orari"),
         required=False,
         description=_(
-            "orari_help",
-            default="Informazioni sugli orari di svolgimento dell'evento.",
+            "orari_help", default="Informazioni sugli orari di svolgimento dell'evento."
         ),
     )
 
@@ -115,9 +109,7 @@ class IEvento(model.Schema):
     )
 
     contatto_reperibilita = schema.TextLine(
-        title=_(
-            u"contatto_reperibilita", default=u"Reperibilità organizzatore"
-        ),
+        title=_(u"contatto_reperibilita", default=u"Reperibilità organizzatore"),
         required=False,
         description=_(
             "contatto_reperibilita_help",
@@ -127,13 +119,10 @@ class IEvento(model.Schema):
     )
 
     organizzato_da_interno = RelationList(
-        title=_(
-            u"Organizzato da_interno", default=u"Organizzato da (interno)"
-        ),
+        title=_(u"Organizzato da_interno", default=u"Organizzato da (interno)"),
         default=[],
         value_type=RelationChoice(
-            title=_(u"Organizzatore"),
-            vocabulary="plone.app.vocabularies.Catalog",
+            title=_(u"Organizzatore"), vocabulary="plone.app.vocabularies.Catalog"
         ),
         required=False,
         description=_(
@@ -188,19 +177,13 @@ class IEvento(model.Schema):
         ),
     )
 
-    box_aiuto = RichText(
-        title=_(u"box_aiuto", default=u"Box di aiuto"), required=False
-    )
-
     # TODO: come gestire correlati: novita'
     model.fieldset(
         "partecipanti",
         label=_("partecipanti_label", default=u"Partecipanti"),
         fields=["descrizione_destinatari", "persone_amministrazione"],
     )
-    model.fieldset(
-        "costi", label=_("costi_label", default=u"Costi"), fields=["prezzo"],
-    )
+    model.fieldset("costi", label=_("costi_label", default=u"Costi"), fields=["prezzo"])
     model.fieldset(
         "contatti",
         label=_("contatti_label", default=u"Contatti"),
@@ -214,7 +197,7 @@ class IEvento(model.Schema):
     model.fieldset(
         "informazioni",
         label=_("informazioni_label", default=u"Informazioni"),
-        fields=["patrocinato_da", "box_aiuto"],
+        fields=["patrocinato_da"],
     )
     model.fieldset(
         "date_evento",

--- a/src/design/plone/contenttypes/behaviors/evento.py
+++ b/src/design/plone/contenttypes/behaviors/evento.py
@@ -59,7 +59,7 @@ class IEvento(model.Schema):
 
     # model.fieldset(
     #     "correlati",
-    #     label=_("correlati_label", default=u"Correlati"),
+    #     label=_("correlati_label", default="Contenuti collegati"),
     #     fields=["luoghi_correlati"],
     # )
 
@@ -126,7 +126,7 @@ class IEvento(model.Schema):
         ),
         required=False,
         description=_(
-            "organizzato_da_esterno_help",
+            "organizzato_da_interno_help",
             default="Se l'evento è organizzato direttamente dal comune,"
             " indicare l'ufficio/ente organizzatore.",
         ),
@@ -196,7 +196,7 @@ class IEvento(model.Schema):
     )
     model.fieldset(
         "informazioni",
-        label=_("informazioni_label", default=u"Informazioni"),
+        label=_("informazioni_label", default=u"Ulteriori informazioni"),
         fields=["patrocinato_da"],
     )
     model.fieldset(

--- a/src/design/plone/contenttypes/behaviors/luoghi_correlati.py
+++ b/src/design/plone/contenttypes/behaviors/luoghi_correlati.py
@@ -17,8 +17,7 @@ class ILuoghiCorrelati(model.Schema):
     luoghi_correlati = RelationList(
         title=_("luoghi_correlati_label", default="Luoghi correlati"),
         description=_(
-            "luoghi_correlati_help",
-            default="Seleziona una lista di luoghi citati.",
+            "luoghi_correlati_help", default="Seleziona una lista di luoghi citati."
         ),
         default=[],
         value_type=RelationChoice(vocabulary="plone.app.vocabularies.Catalog"),
@@ -36,7 +35,7 @@ class ILuoghiCorrelati(model.Schema):
 
     model.fieldset(
         "correlati",
-        label=_("correlati_label", default=u"Correlati"),
+        label=_("correlati_label", default="Contenuti collegati"),
         fields=["luoghi_correlati"],
     )
 
@@ -56,17 +55,14 @@ class ILuoghiCorrelatiEvento(ILuoghiCorrelati):
     luoghi_correlati = RelationList(
         title=_("luoghi_correlati_evento_label", default="Luoghi dell'evento"),
         description=_(
-            "luoghi_correlati_help",
-            default="Seleziona una lista di luoghi citati.",
+            "luoghi_correlati_help", default="Seleziona una lista di luoghi citati."
         ),
         default=[],
         value_type=RelationChoice(vocabulary="plone.app.vocabularies.Catalog"),
         required=False,
     )
     model.fieldset(
-        "dove",
-        label=_("dove_label", default=u"Dove"),
-        fields=["luoghi_correlati"],
+        "dove", label=_("dove_label", default=u"Dove"), fields=["luoghi_correlati"]
     )
 
 

--- a/src/design/plone/contenttypes/behaviors/luogo.py
+++ b/src/design/plone/contenttypes/behaviors/luogo.py
@@ -23,8 +23,7 @@ class ILuogo(model.Schema):
         title=_(u"quartiere", default=u"Quartiere"),
         description=_(
             u"help_quartiere",
-            default=u"Indicare l'eventuale"
-            " quartiere in cui si trova questo luogo",
+            default=u"Indicare l'eventuale" " quartiere in cui si trova questo luogo",
         ),
         required=False,
     )
@@ -64,8 +63,7 @@ class ILuogo(model.Schema):
         title=_(u"elementi_di_interesse", default=u"Elementi di interesse"),
         description=_(
             u"help_elementi_di_interesse",
-            default=u"Indicare eventuali elementi di interesse relativi al"
-            " luogo",
+            default=u"Indicare eventuali elementi di interesse relativi al" " luogo",
         ),
         required=False,
     )
@@ -82,8 +80,7 @@ class ILuogo(model.Schema):
 
     riferimento_telefonico_luogo = schema.TextLine(
         title=_(
-            u"riferimento_telefonico_luogo",
-            default=u"Riferimento telefonico luogo",
+            u"riferimento_telefonico_luogo", default=u"Riferimento telefonico luogo"
         ),
         description=_(
             u"help_riferimento_telefonico_luogo",
@@ -113,9 +110,12 @@ class ILuogo(model.Schema):
     )
 
     struttura_responsabile_correlati = RelationList(
-        title=u"Struttura responsabile del luogo",
+        title=_(
+            "struttura_responsabile_correlati",
+            default=u"Struttura responsabile del luogo",
+        ),
         description=_(
-            "struttura_responsabile_help",
+            "struttura_responsabile_correlati_help",
             default="Indicare la struttura responsabile del luogo qualora sia"
             " fra unità organizzative del comune inserite nel sito; altrimenti"
             " compilare i campi testuali relativi alla struttura responsabile",
@@ -212,7 +212,7 @@ class ILuogo(model.Schema):
 
     # model.fieldset(
     #     "correlati",
-    #     label=_("correlati_label", default=u"Correlati"),
+    #     label=_("correlati_label", default="Contenuti collegati"),
     #     fields=["struttura_responsabile_correlati"],
     # )
     model.fieldset(

--- a/src/design/plone/contenttypes/behaviors/news_additional_fields.py
+++ b/src/design/plone/contenttypes/behaviors/news_additional_fields.py
@@ -18,8 +18,7 @@ class INewsAdditionalFields(model.Schema):
     tipologia_notizia = schema.Choice(
         title=_("tipologia_notizia_label", default="Tipologia notizia"),
         description=_(
-            "tipologia_notizia_help",
-            default="Seleziona la tipologia della notizia.",
+            "tipologia_notizia_help", default="Seleziona la tipologia della notizia."
         ),
         required=True,
         vocabulary="design.plone.vocabularies.tipologie_notizia",
@@ -92,16 +91,13 @@ class INewsAdditionalFields(model.Schema):
         "notizie_correlate",
         RelatedItemsFieldWidget,
         vocabulary="plone.app.vocabularies.Catalog",
-        pattern_options={
-            "maximumSelectionSize": 10,
-            "selectableTypes": ["News Item"],
-        },
+        pattern_options={"maximumSelectionSize": 10, "selectableTypes": ["News Item"]},
     )
 
     # custom fieldsets
     model.fieldset(
         "correlati",
-        label=_("correlati_label", default=u"Correlati"),
+        label=_("correlati_label", default="Contenuti collegati"),
         fields=["notizie_correlate"],
     )
 

--- a/src/design/plone/contenttypes/behaviors/servizi_correlati.py
+++ b/src/design/plone/contenttypes/behaviors/servizi_correlati.py
@@ -32,15 +32,12 @@ class IServiziCorrelati(model.Schema):
         "servizi_correlati",
         RelatedItemsFieldWidget,
         vocabulary="plone.app.vocabularies.Catalog",
-        pattern_options={
-            "maximumSelectionSize": 10,
-            "selectableTypes": ["Servizio"],
-        },
+        pattern_options={"maximumSelectionSize": 10, "selectableTypes": ["Servizio"]},
     )
 
     model.fieldset(
         "correlati",
-        label=_("correlati_label", default=u"Correlati"),
+        label=_("correlati_label", default="Contenuti collegati"),
         fields=["servizi_correlati"],
     )
 

--- a/src/design/plone/contenttypes/behaviors/strutture_correlate.py
+++ b/src/design/plone/contenttypes/behaviors/strutture_correlate.py
@@ -39,7 +39,7 @@ class IStruttureCorrelate(model.Schema):
 
     model.fieldset(
         "correlati",
-        label=_("correlati_label", default=u"Correlati"),
+        label=_("correlati_label", default="Contenuti collegati"),
         fields=["strutture_politiche"],
     )
 

--- a/src/design/plone/contenttypes/events/servizio.py
+++ b/src/design/plone/contenttypes/events/servizio.py
@@ -14,14 +14,13 @@ def servizioCreateHandler(servizio, event):
     """
 
     for folder in [
-        {"id": "modulistica", "title": "Modulistica", "contains": ("File",)},
-        {"id": "allegati", "title": "Allegati", "contains": ("File",)},
+        {"id": "modulistica", "title": "Modulistica", "contains": ("File", "Link")},
+        {"id": "allegati", "title": "Allegati", "contains": ("File", "Link")},
     ]:
         if folder["id"] not in servizio.keys():
             child = api.content.create(
                 type="Document", title=folder["title"], container=servizio
             )
-        else:
             child = servizio[folder["id"]]
             childConstraints = ISelectableConstrainTypes(child)
             childConstraints.setConstrainTypesMode(1)

--- a/src/design/plone/contenttypes/indexers/servizio.py
+++ b/src/design/plone/contenttypes/indexers/servizio.py
@@ -6,15 +6,10 @@ from design.plone.contenttypes.interfaces.servizio import IServizio
 @indexer(IServizio)
 def ufficio_responsabile(context, **kw):
     uffici = context.ufficio_responsabile
-    return [
-        ufficio.UID()
-        for ufficio in filter(bool, [x.to_object for x in uffici])
-    ]
+    return [ufficio.UID() for ufficio in filter(bool, [x.to_object for x in uffici])]
 
 
 @indexer(IServizio)
 def service_venue(context, **kw):
-    luoghi = context.sedi_e_luoghi
-    return [
-        luogo.UID() for luogo in filter(bool, [x.to_object for x in luoghi])
-    ]
+    luoghi = getattr(context, "dove_rivolgersi", [])
+    return [luogo.UID() for luogo in filter(bool, [x.to_object for x in luoghi])]

--- a/src/design/plone/contenttypes/interfaces/documento.py
+++ b/src/design/plone/contenttypes/interfaces/documento.py
@@ -149,8 +149,6 @@ class IDocumento(model.Schema):
         title=_(u"data_protocollo", default=u"Data del protocollo"), required=False
     )
 
-    box_aiuto = RichText(title=_(u"box_aiuto", default=u"Box di aiuto"), required=True)
-
     # come gestiamo "e' parte del life event"?
     # per ora gigavocabolario statico prendendo i valori da github e
     # accumunandoli in una mega lista

--- a/src/design/plone/contenttypes/interfaces/documento_personale.py
+++ b/src/design/plone/contenttypes/interfaces/documento_personale.py
@@ -138,5 +138,3 @@ class IDocumentoPersonale(model.Schema):
         title=_(u"riferimenti_normativi", default=u"Riferimenti normativi"),
         required=False,
     )
-
-    box_aiuto = RichText(title=_(u"box_aiuto", default=u"Box di aiuto"), required=True)

--- a/src/design/plone/contenttypes/interfaces/messaggio.py
+++ b/src/design/plone/contenttypes/interfaces/messaggio.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from design.plone.contenttypes import _
-from plone.app.textfield import RichText
 from plone.namedfile import field
 from plone.supermodel import model
 from zope import schema
@@ -11,8 +10,7 @@ class IMessaggio(model.Schema):
     """
 
     data_messaggio = schema.Date(
-        title=_(u'data_messaggio', default=u'Data del messaggio'),
-        required=True,
+        title=_(u"data_messaggio", default=u"Data del messaggio"), required=True
     )
 
     # "Titolo del messaggio" e "Descrizione" vengono lasciati in titolo e
@@ -21,21 +19,20 @@ class IMessaggio(model.Schema):
     # TODO: aggiungere tassonomia delle tipologie di azioni richieste al
     # cittadino
     azioni_richieste = schema.Choice(
-        title=_(u'azioni_richieste', default=u'Azioni richieste'),
+        title=_(u"azioni_richieste", default=u"Azioni richieste"),
         required=True,
-        vocabulary='design.plone.contenttypes.Mockup',
+        vocabulary="design.plone.contenttypes.Mockup",
     )
 
     azioni_pratica = schema.Choice(
-        title=_(u'azioni_pratica', default=u'Azioni'),
+        title=_(u"azioni_pratica", default=u"Azioni"),
         # vocabolario di riferimento sara' la tassonomia "Lista azioni pratica"
-        vocabulary='design.plone.contenttypes.ListaAzioniPratica',
+        vocabulary="design.plone.contenttypes.ListaAzioniPratica",
         required=True,
     )
 
     pratica_associata = schema.TextLine(
-        title=_(u'pratica_associata', default=u'Pratica associata'),
-        required=True,
+        title=_(u"pratica_associata", default=u"Pratica associata"), required=True
     )
 
     # come gestiamo "Servizio che genera il messaggio"? Link, ref, RichText
@@ -43,25 +40,19 @@ class IMessaggio(model.Schema):
 
     data_scadenza_procedura = schema.Date(
         title=_(
-            u'data_scadenza_procedura',
-            default=u'Data di scadenza della procedura',
+            u"data_scadenza_procedura", default=u"Data di scadenza della procedura"
         ),
         required=False,
     )
 
     # TODO: inserire tassonomia contenente le tipologie di documenti
     tipologia_documento = schema.Choice(
-        title=_(u'tipologia_documento', default=u'Tipologia documento'),
+        title=_(u"tipologia_documento", default=u"Tipologia documento"),
         required=False,
-        vocabulary='design.plone.contenttypes.Mockup',
+        vocabulary="design.plone.contenttypes.Mockup",
         missing_value=(),
     )
 
     documenti_allegati = field.NamedFile(
-        title=_(u'documenti_allegati', default=u'Documenti allegati'),
-        required=False,
-    )
-
-    box_aiuto = RichText(
-        title=_(u'box_aiuto', default=u'Box di aiuto'), required=True
+        title=_(u"documenti_allegati", default=u"Documenti allegati"), required=False
     )

--- a/src/design/plone/contenttypes/interfaces/pagina_argomento.py
+++ b/src/design/plone/contenttypes/interfaces/pagina_argomento.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from collective import dexteritytextindexer
 from design.plone.contenttypes import _
-from plone.app.textfield import RichText
 from plone.app.z3cform.widget import RelatedItemsFieldWidget
 from plone.autoform import directives as form
 from plone.supermodel import model
@@ -53,14 +52,5 @@ class IPaginaArgomento(model.Schema):
         },
     )
 
-    box_aiuto = RichText(
-        title=_(u"box_aiuto", default=u"Box di aiuto"),
-        required=False,
-        description=_(
-            "box_aiuto_help", default="Eventuali contatti di supporto all'utente."
-        ),
-    )
-
     # SearchableText fields
     dexteritytextindexer.searchable("unita_amministrativa_responsabile")
-    dexteritytextindexer.searchable("box_aiuto")

--- a/src/design/plone/contenttypes/interfaces/persona.py
+++ b/src/design/plone/contenttypes/interfaces/persona.py
@@ -38,8 +38,7 @@ class IPersona(model.Schema):
     ruolo = schema.TextLine(
         title=_(u"ruolo", default=u"Ruolo"),
         description=_(
-            "ruolo_help",
-            default="Descrizione testuale del ruolo di questa persona.",
+            "ruolo_help", default="Descrizione testuale del ruolo di questa persona."
         ),
         required=True,
     )
@@ -55,9 +54,7 @@ class IPersona(model.Schema):
     )
 
     data_conclusione_incarico = schema.Date(
-        title=_(
-            u"data_conclusione_incarico", default=u"Data conclusione incarico"
-        ),
+        title=_(u"data_conclusione_incarico", default=u"Data conclusione incarico"),
         description=_(
             "data_conclusione_incarico_help",
             default="Data di conclusione dell'incarico.",
@@ -77,9 +74,7 @@ class IPersona(model.Schema):
 
     telefono = schema.TextLine(
         title=_(u"telefono", default=u"Numero di telefono"),
-        description=_(
-            "telefono_help", default="Contatto telefonico della persona."
-        ),
+        description=_("telefono_help", default="Contatto telefonico della persona."),
         required=False,
     )
 
@@ -90,20 +85,16 @@ class IPersona(model.Schema):
     )
 
     informazioni_di_contatto = RichText(
-        title=_(
-            u"informazioni_di_contatto", default=u"Informazioni di contatto"
-        ),
+        title=_(u"informazioni_di_contatto", default=u"Informazioni di contatto"),
         description=_(
-            "informazioni_di_contatto_help",
-            default="Altre informazioni di contatto.",
+            "informazioni_di_contatto_help", default="Altre informazioni di contatto."
         ),
         required=False,
     )
 
     organizzazione_riferimento = RelationList(
         title=_(
-            u"organizzazione_riferimento",
-            default=u"Organizzazione di riferimento",
+            u"organizzazione_riferimento", default=u"Organizzazione di riferimento"
         ),
         description=_(
             "organizzazione_riferimento_help",
@@ -136,8 +127,7 @@ class IPersona(model.Schema):
             " la persona è responsabile.",
         ),
         value_type=RelationChoice(
-            title=_(u"Responsabile di"),
-            vocabulary="plone.app.vocabularies.Catalog",
+            title=_(u"Responsabile di"), vocabulary="plone.app.vocabularies.Catalog"
         ),
         required=False,
         default=[],
@@ -225,8 +215,7 @@ class IPersona(model.Schema):
     deleghe = RichText(
         title=_(u"deleghe", default=u"Deleghe"),
         description=_(
-            "deleghe_help",
-            default="Elenco delle deleghe a capo della persona.",
+            "deleghe_help", default="Elenco delle deleghe a capo della persona."
         ),
         required=False,
     )
@@ -254,9 +243,7 @@ class IPersona(model.Schema):
     atto_nomina = field.NamedFile(
         title=_(u"atto_nomina", default=u"Atto nomina"),
         required=False,
-        description=_(
-            "atto_nomina_help", default="Atto di nomina della persona."
-        ),
+        description=_("atto_nomina_help", default="Atto di nomina della persona."),
     )
 
     #    situazione_patrimoniale = field.NamedFile(
@@ -288,7 +275,7 @@ class IPersona(model.Schema):
 
     model.fieldset(
         "correlati",
-        label=_("correlati_label", default=u"Correlati"),
+        label=_("correlati_label", default="Contenuti collegati"),
         fields=[
             "organizzazione_riferimento",
             "responsabile_di",

--- a/src/design/plone/contenttypes/interfaces/servizio.py
+++ b/src/design/plone/contenttypes/interfaces/servizio.py
@@ -18,7 +18,7 @@ class IServizio(model.Schema):
     # vocabolario o entrambi?
     # tipologia_servizio
     sottotitolo = schema.TextLine(
-        title=_(u"sottotitolo", default=u"Sottotitolo"),
+        title=_(u"sottotitolo_label", default=u"Sottotitolo"),
         description=_(
             "sottotitolo_help",
             default="Indica un eventuale sottotitolo/titolo alternativo per"
@@ -31,7 +31,7 @@ class IServizio(model.Schema):
     # solo se il servizio
     # non e' attivo
     stato_servizio = schema.Bool(
-        title=_(u"stato_servizio", default=u"Servizio non attivo"),
+        title=_(u"stato_servizio_label", default=u"Servizio non attivo"),
         required=False,
         description=_(
             "stato_servizio_help",
@@ -41,7 +41,7 @@ class IServizio(model.Schema):
 
     motivo_stato_servizio = RichText(
         title=_(
-            u"motivo_stato_servizio",
+            u"motivo_stato_servizio_label",
             default=u"Motivo dello stato del servizio nel caso non sia attivo",
         ),
         required=False,
@@ -51,18 +51,17 @@ class IServizio(model.Schema):
         ),
     )
 
-    descrizione_destinatari = RichText(
-        title=_(u"descrizione_destinatari", default=u"Descrizione destinatari"),
+    a_chi_si_rivolge = RichText(
+        title=_(u"a_chi_si_rivolge_label", default=u"A chi si rivolge"),
         required=False,
         description=_(
-            "descrizione_destinatari_help",
-            default="Descrizione dei principali interlocutori del servizio:"
-            " a chi si rivolge e chi può usufruirne.",
+            "a_chi_si_rivolge_help",
+            default="A chi si rivolge questo servizio e chi può usufruirne.",
         ),
     )
 
     chi_puo_presentare = RichText(
-        title=_(u"chi_puo_presentare", default=u"Chi può presentare"),
+        title=_(u"chi_puo_presentare_label", default=u"Chi può presentare"),
         required=False,
         description=_(
             "chi_puo_presentare_help",
@@ -72,7 +71,7 @@ class IServizio(model.Schema):
     )
 
     copertura_geografica = RichText(
-        title=_(u"copertura_geografica", default=u"Copertura geografica"),
+        title=_(u"copertura_geografica_label", default=u"Copertura geografica"),
         required=False,
         description=_(
             "copertura_geografica_help",
@@ -132,34 +131,49 @@ class IServizio(model.Schema):
         required=False,
     )
 
-    canale_fisico = RichText(
-        title=_(u"canale_fisico", default=u"Canale fisico"),
+    dove_rivolgersi = RelationList(
+        title=u"Dove rivolgersi",
+        default=[],
+        value_type=RelationChoice(vocabulary="plone.app.vocabularies.Catalog"),
+        required=False,
         description=_(
-            "canale_fisico_help",
-            default="Indica le sedi dove è possibile usufruire del servizio.",
+            "dove_rivolgersi_help",
+            default="Seleziona una lista delle sedi e dei luoghi in cui è presente"
+            " questo servizio.",
+        ),
+    )
+
+    dove_rivolgersi_extra = RichText(
+        title=_(
+            u"dove_rivolgersi_extra",
+            default=u"Dove rivolgersi: informazioni aggiuntive",
+        ),
+        description=_(
+            "dove_rivolgersi_extra_help",
+            default="Indicare eventuali informazioni aggiuntive riguardo al dove "
+            "rivolgersi per questo servizio.",
         ),
         required=False,
     )
 
-    canale_fisico_prenotazione = RichText(
-        title=_(u"canale_fisico_prenotazione", default=u"Canale fisico - prenotazione"),
+    prenota_appuntamento = RichText(
+        title=_(u"prenota_appuntamento", default=u"Prenota un appuntamento"),
         description=_(
-            "canale_fisico_prenotazione_help",
+            "prenota_appuntamento_help",
             default="Se è possibile prenotare un'appuntamento, indicare"
-            " il collegamento al servizio di prenotazione appuntamenti"
-            " del Comune.",
+            " le informazioni necessarie e il collegamento al servizio di "
+            "prenotazione appuntamenti del Comune.",
         ),
         required=False,
     )
 
-    fasi_scadenze = RichText(
-        title=_(u"fasi_scadenze", default=u"Fasi e scadenze"),
+    tempi_e_scadenze = RichText(
+        title=_(u"tempi_e_scadenze", default=u"Tempi e scadenze"),
         required=False,
         description=_(
-            "fasi_scadenze_help",
-            default="Prevedere una data di scadenza del servizio."
-            " Se il servizio è diviso in fasi, descriverne modalità e"
-            " tempistiche.",
+            "tempi_e_scadenze_help",
+            default="Descrivere le informazioni dettagliate riguardo eventuali tempi"
+            " e scadenze di questo servizio.",
         ),
     )
 
@@ -218,7 +232,7 @@ class IServizio(model.Schema):
 
     area = RelationList(
         title=_(u"area", default=u"Area"),
-        required=True,
+        required=False,
         default=[],
         description=_(
             "area_help", default="Seleziona l'area da cui dipende questo servizio."
@@ -298,17 +312,6 @@ class IServizio(model.Schema):
         ),
     )
 
-    box_aiuto = RichText(
-        title=_(u"box_aiuto", default=u"Box di aiuto"),
-        required=False,
-        description=_(
-            "box_aiuto_help",
-            default="Ulteriori informazioni sul Servizio, FAQ, eventuali"
-            " riferimenti normativi ed eventuali contatti di supporto"
-            " all'utente.",
-        ),
-    )
-
     servizi_collegati = RelationList(
         title=u"Servizi collegati",
         default=[],
@@ -322,31 +325,17 @@ class IServizio(model.Schema):
         ),
     )
 
-    sedi_e_luoghi = RelationList(
-        title=u"Dove trovarci",
-        default=[],
-        value_type=RelationChoice(
-            title=_(u"Dove trovarci"), vocabulary="plone.app.vocabularies.Catalog"
-        ),
-        required=False,
-        description=_(
-            "sedi_e_luoghi_help",
-            default="Seleziona la lista delle sedi e dei luoghi collegati"
-            " a questo servizio.",
-        ),
-    )
-
     # custom widgets
     form.widget(
-        "sedi_e_luoghi",
+        "dove_rivolgersi",
         RelatedItemsFieldWidget,
         vocabulary="plone.app.vocabularies.Catalog",
         pattern_options={
             "maximumSelectionSize": 10,
-            "selectableTypes": ["Venue"],
-            # "basePath": "/",
+            "selectableTypes": ["Venue", "UnitaOrganizzativa"],
         },
     )
+
     form.widget(
         "area",
         RelatedItemsFieldWidget,
@@ -389,16 +378,83 @@ class IServizio(model.Schema):
     )
 
     # custom fieldset and order
-    model.fieldset("correlati", fields=["servizi_collegati", "altri_documenti"])
+    model.fieldset(
+        "a_chi_si_rivolge",
+        label=_("a_chi_si_rivolge_label", default=u"A chi si rivolge"),
+        fields=["a_chi_si_rivolge", "chi_puo_presentare", "copertura_geografica"],
+    )
+    model.fieldset(
+        "accedi_al_servizio",
+        label=_("accedi_al_servizio_label", default=u"Accedi al servizio"),
+        fields=[
+            "come_si_fa",
+            "cosa_si_ottiene",
+            "procedure_collegate",
+            "canale_digitale",
+            "autenticazione",
+            "dove_rivolgersi",
+            "dove_rivolgersi_extra",
+            "prenota_appuntamento",
+        ],
+    )
+    model.fieldset(
+        "cosa_serve",
+        label=_("cosa_serve_label", default=u"Cosa serve"),
+        fields=["cosa_serve"],
+    )
+    model.fieldset(
+        "costi_e_vincoli",
+        label=_("costi_e_vincoli_label", default=u"Costi e vincoli"),
+        fields=["costi", "vincoli"],
+    )
+
+    model.fieldset(
+        "tempi_e_scadenze",
+        label=_("tempi_e_scadenze_label", default=u"Tempi e scadenze"),
+        fields=["tempi_e_scadenze"],
+    )
+
+    model.fieldset(
+        "casi_particolari",
+        label=_("casi_particolari_label", default=u"Casi particolari"),
+        fields=["casi_particolari"],
+    )
+
+    model.fieldset(
+        "contatti",
+        label=_("contatti_label", default=u"Contatti"),
+        fields=["ufficio_responsabile", "area"],
+    )
+    model.fieldset(
+        "documenti",
+        label=_("documenti_label", default=u"Documenti"),
+        fields=["altri_documenti"],
+    )
+    model.fieldset(
+        "link_utili",
+        label=_("link_utili_label", default=u"Link utili"),
+        fields=["link_siti_esterni"],
+    )
+
+    model.fieldset(
+        "correlati",
+        label=_("correlati_label", default=u"Contenuti collegati"),
+        fields=["servizi_collegati", "altri_documenti"],
+    )
+
+    model.fieldset(
+        "categorization",
+        fields=["life_event", "codice_ipa", "settore_merceologico", "identificativo"],
+    )
 
     # SearchableText fields
     dexteritytextindexer.searchable("sottotitolo")
-    dexteritytextindexer.searchable("descrizione_destinatari")
+    dexteritytextindexer.searchable("a_chi_si_rivolge")
     dexteritytextindexer.searchable("chi_puo_presentare")
     dexteritytextindexer.searchable("come_si_fa")
     dexteritytextindexer.searchable("cosa_si_ottiene")
     dexteritytextindexer.searchable("cosa_serve")
-    dexteritytextindexer.searchable("box_aiuto")
+    dexteritytextindexer.searchable("ulteriori_informazioni")
     dexteritytextindexer.searchable("area")
     dexteritytextindexer.searchable("ufficio_responsabile")
     dexteritytextindexer.searchable("copertura_geografica")

--- a/src/design/plone/contenttypes/interfaces/servizio.py
+++ b/src/design/plone/contenttypes/interfaces/servizio.py
@@ -439,7 +439,7 @@ class IServizio(model.Schema):
     model.fieldset(
         "correlati",
         label=_("correlati_label", default=u"Contenuti collegati"),
-        fields=["servizi_collegati", "altri_documenti"],
+        fields=["servizi_collegati"],
     )
 
     model.fieldset(
@@ -454,7 +454,6 @@ class IServizio(model.Schema):
     dexteritytextindexer.searchable("come_si_fa")
     dexteritytextindexer.searchable("cosa_si_ottiene")
     dexteritytextindexer.searchable("cosa_serve")
-    dexteritytextindexer.searchable("ulteriori_informazioni")
     dexteritytextindexer.searchable("area")
     dexteritytextindexer.searchable("ufficio_responsabile")
     dexteritytextindexer.searchable("copertura_geografica")

--- a/src/design/plone/contenttypes/interfaces/unita_organizzativa.py
+++ b/src/design/plone/contenttypes/interfaces/unita_organizzativa.py
@@ -169,7 +169,7 @@ class IUnitaOrganizzativa(model.Schema):
     # custom fieldsets and order
     model.fieldset(
         "correlati",
-        label=_("correlati_label", default=u"Correlati"),
+        label=_("correlati_label", default="Contenuti collegati"),
         fields=["legami_con_altre_strutture"],
     )
 

--- a/src/design/plone/contenttypes/interfaces/unita_organizzativa.py
+++ b/src/design/plone/contenttypes/interfaces/unita_organizzativa.py
@@ -36,21 +36,6 @@ class IUnitaOrganizzativa(model.Schema):
         ),
         required=False,
     )
-    model.fieldset(
-        "correlati",
-        label=_("correlati_label", default=u"Correlati"),
-        fields=["legami_con_altre_strutture"],
-    )
-
-    form.widget(
-        "legami_con_altre_strutture",
-        RelatedItemsFieldWidget,
-        vocabulary="plone.app.vocabularies.Catalog",
-        pattern_options={
-            "maximumSelectionSize": 10,
-            "selectableTypes": ["UnitaOrganizzativa"],
-        },
-    )
 
     responsabile = RelationList(
         title=u"Responsabile",
@@ -63,16 +48,6 @@ class IUnitaOrganizzativa(model.Schema):
         ),
         default=[],
         required=False,
-    )
-    form.widget(
-        "responsabile",
-        RelatedItemsFieldWidget,
-        vocabulary="plone.app.vocabularies.Catalog",
-        pattern_options={
-            "maximumSelectionSize": 1,
-            "selectableTypes": ["Persona"],
-            # "basePath": "/amministrazione",
-        },
     )
 
     tipologia_organizzazione = schema.Choice(
@@ -103,16 +78,6 @@ class IUnitaOrganizzativa(model.Schema):
         required=False,
         default=[],
     )
-    form.widget(
-        "assessore_riferimento",
-        RelatedItemsFieldWidget,
-        vocabulary="plone.app.vocabularies.Catalog",
-        pattern_options={
-            "maximumSelectionSize": 1,
-            "selectableTypes": ["Persona"],
-            # "basePath": "/amministrazione",
-        },
-    )
 
     # vocabolario di riferimento sara' dinamico con i content type persona
     persone_struttura = RelationList(
@@ -128,47 +93,9 @@ class IUnitaOrganizzativa(model.Schema):
         ),
         required=False,
     )
-    form.widget(
-        "persone_struttura",
-        RelatedItemsFieldWidget,
-        vocabulary="plone.app.vocabularies.Catalog",
-        pattern_options={
-            "maximumSelectionSize": 10,
-            "selectableTypes": ["Persona"],
-            # "basePath": "/amministrazione",
-        },
-    )
-
-    # # vocabolario di riferimento sara' da definire, probabilmente dinamico
-    # dai ct servizi presenti nella macro Amministrazione"
-    # servizi_offerti = RelationList(
-    #     title=u"Servizi offerti",
-    #     default=[],
-    #     value_type=RelationChoice(
-    #         title=_(u"Servizio"), vocabulary="plone.app.vocabularies.Catalog"
-    #     ),
-    #     required=False,
-    # )
-    # form.widget(
-    #     "servizi_offerti",
-    #     RelatedItemsFieldWidget,
-    #     pattern_options={
-    #         "maximumSelectionSize": 10,
-    #         "selectableTypes": ["Servizio"],
-    #         # "basePath": "/servizi",
-    #     },
-    # )
 
     ulteriori_informazioni = RichText(
         title=_(u"unteriori_informazioni", default=u"Informazioni"), required=False
-    )
-
-    box_aiuto = RichText(
-        title=_(u"box_aiuto", default=u"Box di aiuto"),
-        required=False,
-        description=_(
-            "uo_box_aiuto_help", default="Eventuali contatti di supporto all'utente."
-        ),
     )
 
     sedi = RelationList(
@@ -182,6 +109,52 @@ class IUnitaOrganizzativa(model.Schema):
         ),
         required=False,
     )
+
+    contact_info = RichText(
+        title=_(u"contact_info", default=u"Informazioni di contatto generiche"),
+        required=False,
+        description=_(
+            "uo_contact_info_description",
+            default="Eventuali informazioni di contatto generiche",
+        ),
+    )
+
+    #  custom widgets
+    form.widget(
+        "persone_struttura",
+        RelatedItemsFieldWidget,
+        vocabulary="plone.app.vocabularies.Catalog",
+        pattern_options={"maximumSelectionSize": 10, "selectableTypes": ["Persona"]},
+    )
+    form.widget(
+        "legami_con_altre_strutture",
+        RelatedItemsFieldWidget,
+        vocabulary="plone.app.vocabularies.Catalog",
+        pattern_options={
+            "maximumSelectionSize": 10,
+            "selectableTypes": ["UnitaOrganizzativa"],
+        },
+    )
+    form.widget(
+        "responsabile",
+        RelatedItemsFieldWidget,
+        vocabulary="plone.app.vocabularies.Catalog",
+        pattern_options={
+            "maximumSelectionSize": 1,
+            "selectableTypes": ["Persona"],
+            # "basePath": "/amministrazione",
+        },
+    )
+    form.widget(
+        "assessore_riferimento",
+        RelatedItemsFieldWidget,
+        vocabulary="plone.app.vocabularies.Catalog",
+        pattern_options={
+            "maximumSelectionSize": 1,
+            "selectableTypes": ["Persona"],
+            # "basePath": "/amministrazione",
+        },
+    )
     form.widget(
         "sedi",
         RelatedItemsFieldWidget,
@@ -192,14 +165,15 @@ class IUnitaOrganizzativa(model.Schema):
             # "basePath": "/servizi",
         },
     )
-    contact_info = RichText(
-        title=_(u"contact_info", default=u"Informazioni di contatto generiche"),
-        required=False,
-        description=_(
-            "uo_contact_info_description",
-            default="Eventuali informazioni di contatto generiche",
-        ),
+
+    # custom fieldsets and order
+    model.fieldset(
+        "correlati",
+        label=_("correlati_label", default=u"Correlati"),
+        fields=["legami_con_altre_strutture"],
     )
+
+    form.order_after(sedi="IGeolocatable.geolocation")
 
     # SearchableText indexers
     dexteritytextindexer.searchable("competenze")

--- a/src/design/plone/contenttypes/interfaces/unita_organizzativa.py
+++ b/src/design/plone/contenttypes/interfaces/unita_organizzativa.py
@@ -94,10 +94,6 @@ class IUnitaOrganizzativa(model.Schema):
         required=False,
     )
 
-    ulteriori_informazioni = RichText(
-        title=_(u"unteriori_informazioni", default=u"Informazioni"), required=False
-    )
-
     sedi = RelationList(
         title=u"Altre sedi",
         default=[],

--- a/src/design/plone/contenttypes/locales/design.plone.contenttypes.pot
+++ b/src/design/plone/contenttypes/locales/design.plone.contenttypes.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-07-14 15:00+0000\n"
+"POT-Creation-Date: 2020-09-04 09:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: design.plone.contenttypes\n"
 
-#: design/plone/contenttypes/interfaces/documento.py:43
+#: design/plone/contenttypes/interfaces/documento.py:35
 msgid ""
 msgstr ""
 
@@ -25,11 +25,11 @@ msgstr ""
 msgid "Abitazione"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:42
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:37
 msgid "Accesso al trasporto pubblico"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:70
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:62
 msgid "Accesso luoghi della cultura"
 msgstr ""
 
@@ -73,32 +73,27 @@ msgstr ""
 msgid "Anziano"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:254
+#: design/plone/contenttypes/interfaces/servizio.py:241
 msgid "Area"
-msgstr ""
-
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:20
-msgid "Area di appartenenza"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:53
 msgid "Area di parcheggio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:63
+#: design/plone/contenttypes/interfaces/documento.py:52
 msgid "Area responsabile"
 msgstr ""
 
 #: design/plone/contenttypes/behaviors/configure.zcml:45
-#: design/plone/contenttypes/behaviors/evento.py:61
 msgid "Argomenti"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:41
-msgid "Assessorati di riferimento"
+#: design/plone/contenttypes/behaviors/argomenti.py:27
+msgid "Argomenti correlati"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:98
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:70
 msgid "Assessore di riferimento"
 msgstr ""
 
@@ -114,8 +109,8 @@ msgstr ""
 msgid "Atto normativo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:82
-#: design/plone/contenttypes/interfaces/documento_personale.py:89
+#: design/plone/contenttypes/interfaces/documento.py:70
+#: design/plone/contenttypes/interfaces/documento_personale.py:83
 msgid "Autore"
 msgstr ""
 
@@ -123,19 +118,19 @@ msgstr ""
 msgid "Autorizzare"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:81
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:73
 msgid "Avvio impresa"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:82
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:74
 msgid "Avvio nuova attività professionale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:85
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:77
 msgid "Avvio/registrazione filiale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:96
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:86
 msgid "Bancarotta"
 msgstr ""
 
@@ -143,11 +138,11 @@ msgstr ""
 msgid "CAP"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:49
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:44
 msgid "Cambio di residenza/domicilio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:122
+#: design/plone/contenttypes/interfaces/documento.py:109
 msgid "Canale digitale al servizio collegato"
 msgstr ""
 
@@ -155,11 +150,11 @@ msgstr ""
 msgid "Canon 5D IV"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:93
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:83
 msgid "Chiusura filiale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:91
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:82
 msgid "Chiusura impresa e attività professionale"
 msgstr ""
 
@@ -167,15 +162,15 @@ msgstr ""
 msgid "Città"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:123
+#: design/plone/contenttypes/interfaces/persona.py:161
 msgid "Collegamenti organizzazione di I livello"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:152
+#: design/plone/contenttypes/interfaces/persona.py:190
 msgid "Collegamenti organizzazione di II livello"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:45
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:40
 msgid "Compravendita/affitto casa/edifici/terreni, costruzione o ristrutturazione casa/edificio	"
 msgstr ""
 
@@ -195,17 +190,17 @@ msgstr ""
 msgid "Cultura"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:140
-#: design/plone/contenttypes/interfaces/documento_personale.py:133
+#: design/plone/contenttypes/interfaces/documento.py:127
+#: design/plone/contenttypes/interfaces/documento_personale.py:125
 #: design/plone/contenttypes/profiles/default/types/Dataset.xml
 msgid "Dataset"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento_personale.py:137
+#: design/plone/contenttypes/interfaces/documento_personale.py:129
 msgid "Dataset collegato"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:65
+#: design/plone/contenttypes/behaviors/configure.zcml:82
 msgid "Dataset correlati"
 msgstr ""
 
@@ -213,8 +208,12 @@ msgstr ""
 msgid "Delegare"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:63
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:55
 msgid "Denuncia crimini"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:130
+msgid "Descrizione estesa"
 msgstr ""
 
 #: design/plone/contenttypes/configure.zcml:34
@@ -225,7 +224,7 @@ msgstr ""
 msgid "Design Plone: Content-types (uninstall)"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:66
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:58
 msgid "Dichiarazione dei redditi, versamento e riscossione tributi/imposte e contributi"
 msgstr ""
 
@@ -233,7 +232,7 @@ msgstr ""
 msgid "Documenti albo pretorio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:278
+#: design/plone/contenttypes/interfaces/servizio.py:254
 #: design/plone/contenttypes/profiles/default/types/Documento.xml
 msgid "Documento"
 msgstr ""
@@ -252,10 +251,6 @@ msgstr ""
 
 #: design/plone/contenttypes/vocabularies/document_types_vocabulary.py:34
 msgid "Documento funzionamento interno"
-msgstr ""
-
-#: design/plone/contenttypes/interfaces/servizio.py:387
-msgid "Dove trovarci"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/dataset.py:31
@@ -277,11 +272,7 @@ msgstr ""
 msgid "Energia"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:247
-msgid "Evento figlio"
-msgstr ""
-
-#: design/plone/contenttypes/behaviors/evento.py:224
+#: design/plone/contenttypes/behaviors/evento.py:150
 msgid "Evento supportato da"
 msgstr ""
 
@@ -293,7 +284,7 @@ msgstr ""
 msgid "Fanciullo"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:86
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:78
 msgid "Finanziamento impresa"
 msgstr ""
 
@@ -310,7 +301,7 @@ msgstr ""
 msgid "Gestione dei rifiuti"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:87
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:79
 msgid "Gestione personale"
 msgstr ""
 
@@ -340,6 +331,10 @@ msgstr ""
 
 #: design/plone/contenttypes/controlpanels/vocabularies.py:35
 msgid "Indicare le dimensioni delle lead image dei contenuti"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:141
+msgid "Info per la testata"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/lista_azioni_pratica.py:33
@@ -374,7 +369,7 @@ msgstr ""
 msgid "Integrazione sociale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:34
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:29
 msgid "Invalidità"
 msgstr ""
 
@@ -382,7 +377,7 @@ msgstr ""
 msgid "Iscriversi"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:30
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:25
 msgid "Iscrizione scuola/università e/o richiesta borsa di studio"
 msgstr ""
 
@@ -402,19 +397,15 @@ msgstr ""
 msgid "Leggere"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:55
+#: design/plone/contenttypes/behaviors/configure.zcml:63
 msgid "Luoghi correlati"
-msgstr ""
-
-#: design/plone/contenttypes/behaviors/evento.py:128
-msgid "Luogo dell'evento"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:47
 msgid "Matrimonio"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:60
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:52
 msgid "Matrimonio e/o cambio stato civile"
 msgstr ""
 
@@ -438,11 +429,11 @@ msgstr ""
 msgid "Modulistica"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:61
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:53
 msgid "Morte ed eredità"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:58
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:51
 msgid "Nascita di un bambino, richiesta adozioni"
 msgstr ""
 
@@ -450,24 +441,29 @@ msgstr ""
 msgid "Nazione"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:89
+#. Default: "Nome e cognome"
+#: design/plone/contenttypes/restapi/services/types/get.py:106
+msgid "Nome e Cognome"
+msgstr ""
+
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:81
 msgid "Notifiche autorità"
 msgstr ""
 
 #. Default: "Organizzato da (interno)"
-#: design/plone/contenttypes/behaviors/evento.py:172
+#: design/plone/contenttypes/behaviors/evento.py:122
 msgid "Organizzato da_interno"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:177
+#: design/plone/contenttypes/behaviors/evento.py:125
 msgid "Organizzatore"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:45
+#: design/plone/contenttypes/interfaces/persona.py:105
 msgid "Organizzazione di riferimento"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:88
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:80
 msgid "Pagamento tasse, iva e dogane"
 msgstr ""
 
@@ -483,11 +479,11 @@ msgstr ""
 msgid "Paperino"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:99
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:89
 msgid "Partecipazione ad appalti pubblici nazionali e trasfrontalieri"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:39
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:34
 msgid "Pensionamento"
 msgstr ""
 
@@ -495,11 +491,11 @@ msgstr ""
 msgid "Persona"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:109
-msgid "Persona dell'amminnistrazione"
+#: design/plone/contenttypes/behaviors/evento.py:43
+msgid "Persona dell'amministrazione"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:125
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:87
 msgid "Persone della struttura"
 msgstr ""
 
@@ -519,7 +515,7 @@ msgstr ""
 msgid "Popolazione e società"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:73
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:65
 msgid "Possesso, cura, smarrimento animale da compagnia"
 msgstr ""
 
@@ -527,7 +523,7 @@ msgstr ""
 msgid "Pratica"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:62
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:54
 msgid "Prenotazione e disdetta visite/esami"
 msgstr ""
 
@@ -539,23 +535,23 @@ msgstr ""
 msgid "Regioni e città"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:84
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:76
 msgid "Registrazione impresa transfrontalier"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:41
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:36
 msgid "Registrazione/possesso veicolo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:57
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:43
 msgid "Responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:70
+#: design/plone/contenttypes/interfaces/persona.py:130
 msgid "Responsabile di"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:37
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:32
 msgid "Ricerca di lavoro, avvio nuovo lavoro, disoccupazione"
 msgstr ""
 
@@ -567,19 +563,19 @@ msgstr ""
 msgid "Richiedere"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:83
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:75
 msgid "Richiesta licenze/permessi/certificati"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:40
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:35
 msgid "Richiesta o rinnovo patente"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:53
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:47
 msgid "Richiesta passaporto, visto e assistenza viaggi internazionali"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:94
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:84
 msgid "Ristrutturazione impresa"
 msgstr ""
 
@@ -592,15 +588,15 @@ msgstr ""
 msgid "Scienza e tecnologia"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:188
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:108
 msgid "Sede"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:364
+#: design/plone/contenttypes/interfaces/servizio.py:319
 msgid "Servizi collegati"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:75
+#: design/plone/contenttypes/behaviors/configure.zcml:92
 msgid "Servizi correlati"
 msgstr ""
 
@@ -608,8 +604,8 @@ msgstr ""
 msgid "Servizio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:106
-#: design/plone/contenttypes/interfaces/documento_personale.py:104
+#: design/plone/contenttypes/interfaces/documento.py:94
+#: design/plone/contenttypes/interfaces/documento_personale.py:98
 msgid "Servizio collegato"
 msgstr ""
 
@@ -633,16 +629,20 @@ msgstr ""
 msgid "Sport"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:34
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:35
 msgid "Struttura"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:274
+#: design/plone/contenttypes/behaviors/strutture_correlate.py:20
 msgid "Struttura politica coinvolta"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/luogo.py:116
+#: design/plone/contenttypes/behaviors/luogo.py:124
 msgid "Struttura responsabile"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:102
+msgid "Strutture correlate"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:30
@@ -685,11 +685,11 @@ msgstr ""
 msgid "Turismo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:231
+#: design/plone/contenttypes/interfaces/servizio.py:228
 msgid "Ufficio responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:85
+#: design/plone/contenttypes/behaviors/configure.zcml:112
 msgid "Ulteriori campi aiuto testuali"
 msgstr ""
 
@@ -701,11 +701,15 @@ msgstr ""
 msgid "Unita Organizzativa"
 msgstr ""
 
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:35
+msgid "Unità amministrativa responsabile"
+msgstr ""
+
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:38
 msgid "Urbanistica ed edilizia"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:95
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:85
 msgid "Vendita impresa"
 msgstr ""
 
@@ -727,24 +731,39 @@ msgstr ""
 msgid "Vocabolari Design Plone"
 msgstr ""
 
+#. Default: "A chi si rivolge questo servizio e chi può usufruirne."
+#: design/plone/contenttypes/interfaces/servizio.py:57
+msgid "a_chi_si_rivolge_help"
+msgstr ""
+
+#. Default: "A chi si rivolge"
+#: design/plone/contenttypes/interfaces/servizio.py:55
+msgid "a_chi_si_rivolge_label"
+msgstr ""
+
 #. Default: "Seleziona l'ufficio di comunicazione responsabile di questa notizia/comunicato stampa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:39
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:38
 msgid "a_cura_di_help"
 msgstr ""
 
 #. Default: "A cura di"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:38
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:37
 msgid "a_cura_di_label"
 msgstr ""
 
 #. Default: "Seleziona una lista di persone dell'amministrazione citate in questa notizia/comunicato stampa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:51
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:50
 msgid "a_cura_di_persone_help"
 msgstr ""
 
 #. Default: "Persone"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:50
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:49
 msgid "a_cura_di_persone_label"
+msgstr ""
+
+#. Default: "Accedi al servizio"
+#: design/plone/contenttypes/interfaces/servizio.py:388
+msgid "accedi_al_servizio_label"
 msgstr ""
 
 #. Default: "Allegato"
@@ -753,77 +772,67 @@ msgid "allegato"
 msgstr ""
 
 #. Default: "Seleziona la lista dei documenti di supporto collegati a questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:272
+#: design/plone/contenttypes/interfaces/servizio.py:248
 msgid "altri_documenti_help"
 msgstr ""
 
 #. Default: "Area"
-#: design/plone/contenttypes/interfaces/servizio.py:246
+#: design/plone/contenttypes/interfaces/servizio.py:234
 msgid "area"
 msgstr ""
 
-#. Default: "Area di appartenenza"
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:16
-msgid "area_di_appartenenza"
-msgstr ""
-
 #. Default: "Seleziona l'area da cui dipende questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:249
+#: design/plone/contenttypes/interfaces/servizio.py:237
 msgid "area_help"
 msgstr ""
 
 #. Default: "Area responsabile del documento"
-#: design/plone/contenttypes/interfaces/documento.py:58
+#: design/plone/contenttypes/interfaces/documento.py:49
 msgid "area_responsabile"
 msgstr ""
 
 #. Default: "Area responsabile"
-#: design/plone/contenttypes/interfaces/documento_personale.py:79
+#: design/plone/contenttypes/interfaces/documento_personale.py:73
 msgid "area_responsabile_documento_personale"
 msgstr ""
 
 #. Default: "Argomenti utenti"
-#: design/plone/contenttypes/interfaces/documento_personale.py:46
+#: design/plone/contenttypes/interfaces/documento_personale.py:43
 msgid "argomenti_utenti"
 msgstr ""
 
-#. Default: "Assessorati di riferimento"
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:35
-msgid "assessorati_riferimento"
-msgstr ""
-
 #. Default: "Inserire l'assessore di riferimento della struttura, se esiste."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:101
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:73
 msgid "assessore_riferimento_help"
 msgstr ""
 
 #. Default: "Atto nomina"
-#: design/plone/contenttypes/interfaces/persona.py:252
+#: design/plone/contenttypes/interfaces/persona.py:244
 msgid "atto_nomina"
 msgstr ""
 
 #. Default: "Atto di nomina della persona."
-#: design/plone/contenttypes/interfaces/persona.py:254
+#: design/plone/contenttypes/interfaces/persona.py:246
 msgid "atto_nomina_help"
 msgstr ""
 
 #. Default: "Autenticazione"
-#: design/plone/contenttypes/interfaces/servizio.py:139
+#: design/plone/contenttypes/interfaces/servizio.py:125
 msgid "autenticazione"
 msgstr ""
 
 #. Default: "Indicare, se previste, le modalità di autenticazione necessarie per poter accedere al servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:140
+#: design/plone/contenttypes/interfaces/servizio.py:126
 msgid "autenticazione_help"
 msgstr ""
 
 #. Default: "Azioni"
-#: design/plone/contenttypes/interfaces/messaggio.py:30
+#: design/plone/contenttypes/interfaces/messaggio.py:28
 msgid "azioni_pratica"
 msgstr ""
 
 #. Default: "Azioni richieste"
-#: design/plone/contenttypes/interfaces/messaggio.py:24
+#: design/plone/contenttypes/interfaces/messaggio.py:22
 msgid "azioni_richieste"
 msgstr ""
 
@@ -833,151 +842,113 @@ msgid "azioni_utente"
 msgstr ""
 
 #. Default: "Biografia"
-#: design/plone/contenttypes/interfaces/persona.py:198
+#: design/plone/contenttypes/interfaces/persona.py:66
 msgid "biografia"
 msgstr ""
 
 #. Default: "Solo per persona politica: testo descrittivo che riporta la biografia della persona."
-#: design/plone/contenttypes/interfaces/persona.py:199
+#: design/plone/contenttypes/interfaces/persona.py:67
 msgid "biografia_help"
 msgstr ""
 
-#. Default: "Box di aiuto"
-#: design/plone/contenttypes/behaviors/evento.py:290
-#: design/plone/contenttypes/interfaces/documento.py:170
-#: design/plone/contenttypes/interfaces/documento_personale.py:153
-msgid "box_aiuto"
-msgstr ""
-
-#. Default: "Ulteriori informazioni sul Servizio, FAQ, eventuali riferimenti normativi ed eventuali contatti di supporto all'utente."
-#: design/plone/contenttypes/interfaces/servizio.py:352
-msgid "box_aiuto_help"
-msgstr ""
-
 #. Default: "Canale digitale"
-#: design/plone/contenttypes/interfaces/servizio.py:129
+#: design/plone/contenttypes/interfaces/servizio.py:115
 msgid "canale_digitale"
 msgstr ""
 
 #. Default: "Collegamento con l'eventuale canale digitale di attivazione del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:130
+#: design/plone/contenttypes/interfaces/servizio.py:116
 msgid "canale_digitale_help"
 msgstr ""
 
 #. Default: "Canale digitale servizio collegato"
-#: design/plone/contenttypes/interfaces/documento_personale.py:111
+#: design/plone/contenttypes/interfaces/documento_personale.py:104
 msgid "canale_digitale_servizio"
 msgstr ""
 
-#. Default: "Canale fisico"
-#: design/plone/contenttypes/interfaces/servizio.py:149
-msgid "canale_fisico"
-msgstr ""
-
-#. Default: "Indica le sedi dove è possibile usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:150
-msgid "canale_fisico_help"
-msgstr ""
-
-#. Default: "Canale fisico - prenotazione"
-#: design/plone/contenttypes/interfaces/servizio.py:158
-msgid "canale_fisico_prenotazione"
-msgstr ""
-
-#. Default: "Se è possibile prenotare un'appuntamento, indicare il collegamento al servizio di prenotazione appuntamenti del Comune."
-#: design/plone/contenttypes/interfaces/servizio.py:162
-msgid "canale_fisico_prenotazione_help"
-msgstr ""
-
-#. Default: "CAP"
-#: design/plone/contenttypes/behaviors/evento.py:153
-msgid "cap"
-msgstr ""
-
 #. Default: "Casi particolari"
-#: design/plone/contenttypes/interfaces/servizio.py:211
+#: design/plone/contenttypes/interfaces/servizio.py:208
 msgid "casi_particolari"
 msgstr ""
 
 #. Default: "Descrizione degli evetuali casi particolari riferiti alla fruibilità di questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:213
+#: design/plone/contenttypes/interfaces/servizio.py:210
 msgid "casi_particolari_help"
 msgstr ""
 
-#. Default: "Categoria prevalente"
-#: design/plone/contenttypes/behaviors/luogo.py:96
-msgid "categoria_prevalente"
-msgstr ""
-
-#. Default: "Chi può presentare"
-#: design/plone/contenttypes/interfaces/servizio.py:76
-msgid "chi_puo_presentare"
+#. Default: "Casi particolari"
+#: design/plone/contenttypes/interfaces/servizio.py:419
+msgid "casi_particolari_label"
 msgstr ""
 
 #. Default: "Descrizione di chi può presentare domanda per usufruire del servizio e delle diverse casistiche."
-#: design/plone/contenttypes/interfaces/servizio.py:78
+#: design/plone/contenttypes/interfaces/servizio.py:66
 msgid "chi_puo_presentare_help"
 msgstr ""
 
+#. Default: "Chi può presentare"
+#: design/plone/contenttypes/interfaces/servizio.py:64
+msgid "chi_puo_presentare_label"
+msgstr ""
+
 #. Default: "Circoscrizione"
-#: design/plone/contenttypes/behaviors/evento.py:150
-#: design/plone/contenttypes/behaviors/luogo.py:26
+#: design/plone/contenttypes/behaviors/luogo.py:32
 msgid "circoscrizione"
 msgstr ""
 
 #. Default: "Codice dell'ente erogatore (ipa)"
-#: design/plone/contenttypes/interfaces/servizio.py:319
+#: design/plone/contenttypes/interfaces/servizio.py:285
 msgid "codice_ipa"
 msgstr ""
 
 #. Default: "Specificare il nome dell’organizzazione, come indicato nell’Indice della Pubblica Amministrazione (IPA), che esercita uno specifico ruolo sul Servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:321
+#: design/plone/contenttypes/interfaces/servizio.py:287
 msgid "codice_ipa_help"
 msgstr ""
 
 #. Default: "Collegamenti all'organizzazione di I livello"
-#: design/plone/contenttypes/interfaces/persona.py:109
+#: design/plone/contenttypes/interfaces/persona.py:147
 msgid "collegamenti_organizzazione_l1"
 msgstr ""
 
 #. Default: "Seleziona l'organizzazione a cui la persona è collegata. Se si tratta di una persona politica, il collegamento è riferito a una struttura politica. Se si tratta di una persona amministrativa, il collegamento è riferito ad un'area amministrativa."
-#: design/plone/contenttypes/interfaces/persona.py:113
+#: design/plone/contenttypes/interfaces/persona.py:151
 msgid "collegamenti_organizzazione_l1_help"
 msgstr ""
 
 #. Default: "Collegamenti all'organizzazione di II livello"
-#: design/plone/contenttypes/interfaces/persona.py:140
+#: design/plone/contenttypes/interfaces/persona.py:178
 msgid "collegamenti_organizzazione_l2"
 msgstr ""
 
 #. Default: "Seleziona gli assessorati di cui la persona si occupa,  i gruppi politici, commissioni a cui appartiene, oppure gli uffici di cui si occupa o di cui è responsabile."
-#: design/plone/contenttypes/interfaces/persona.py:144
+#: design/plone/contenttypes/interfaces/persona.py:182
 msgid "collegamenti_organizzazione_l2_help"
 msgstr ""
 
 #. Default: "Come si fa"
-#: design/plone/contenttypes/interfaces/servizio.py:96
+#: design/plone/contenttypes/interfaces/servizio.py:84
 msgid "come_si_fa"
 msgstr ""
 
 #. Default: "Descrizione della procedura da seguire per poter usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:98
+#: design/plone/contenttypes/interfaces/servizio.py:86
 msgid "come_si_fa_help"
 msgstr ""
 
 #. Default: "Competenze"
-#: design/plone/contenttypes/interfaces/persona.py:169
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:17
+#: design/plone/contenttypes/interfaces/persona.py:207
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:18
 msgid "competenze"
 msgstr ""
 
 #. Default: "Descrizione del ruolo e dei compiti della persona."
-#: design/plone/contenttypes/interfaces/persona.py:170
+#: design/plone/contenttypes/interfaces/persona.py:208
 msgid "competenze_help"
 msgstr ""
 
 #. Default: "Informazioni di contatto generiche"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:203
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:114
 msgid "contact_info"
 msgstr ""
 
@@ -987,13 +958,20 @@ msgid "contatti"
 msgstr ""
 
 #. Default: "Contatti"
-#: design/plone/contenttypes/behaviors/luogo.py:149
+#: design/plone/contenttypes/behaviors/evento.py:189
+#: design/plone/contenttypes/behaviors/luogo.py:220
+#: design/plone/contenttypes/interfaces/servizio.py:425
 msgid "contatti_label"
 msgstr ""
 
-#. Default: "Contatto: reperibilità"
-#: design/plone/contenttypes/behaviors/evento.py:203
+#. Default: "Reperibilità organizzatore"
+#: design/plone/contenttypes/behaviors/evento.py:112
 msgid "contatto_reperibilita"
+msgstr ""
+
+#. Default: "Indicare gli orari in cui l'organizzatore è telefonicamente reperibile."
+#: design/plone/contenttypes/behaviors/evento.py:114
+msgid "contatto_reperibilita_help"
 msgstr ""
 
 #. Default: "Contenuto"
@@ -1001,101 +979,116 @@ msgstr ""
 msgid "contenuto"
 msgstr ""
 
-#. Default: "Copertura geografica"
-#: design/plone/contenttypes/interfaces/servizio.py:86
-msgid "copertura_geografica"
-msgstr ""
-
 #. Default: "Indicare se il servizio si riferisce ad una particolare area geografica o all'intero territorio di riferimento."
-#: design/plone/contenttypes/interfaces/servizio.py:88
+#: design/plone/contenttypes/interfaces/servizio.py:76
 msgid "copertura_geografica_help"
 msgstr ""
 
-#. Default: "Correlati"
-#: design/plone/contenttypes/behaviors/argomenti.py:38
+#. Default: "Copertura geografica"
+#: design/plone/contenttypes/interfaces/servizio.py:74
+msgid "copertura_geografica_label"
+msgstr ""
+
+#. Default: "Contenuti collegati"
+#: design/plone/contenttypes/behaviors/argomenti.py:44
 #: design/plone/contenttypes/behaviors/dataset_correlati.py:40
-#: design/plone/contenttypes/behaviors/luoghi_correlati.py:39
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:38
 msgid "correlati_label"
 msgstr ""
 
 #. Default: "Cosa serve"
-#: design/plone/contenttypes/interfaces/servizio.py:183
+#: design/plone/contenttypes/interfaces/servizio.py:181
 msgid "cosa_serve"
 msgstr ""
 
 #. Default: "Descrizione delle istruzioni per usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:185
+#: design/plone/contenttypes/interfaces/servizio.py:183
 msgid "cosa_serve_help"
 msgstr ""
 
+#. Default: "Cosa serve"
+#: design/plone/contenttypes/interfaces/servizio.py:402
+msgid "cosa_serve_label"
+msgstr ""
+
 #. Default: "Cosa si ottiene"
-#: design/plone/contenttypes/interfaces/servizio.py:106
+#: design/plone/contenttypes/interfaces/servizio.py:94
 msgid "cosa_si_ottiene"
 msgstr ""
 
 #. Default: "Indicare cosa si può ottenere dal servizio, ad esempio 'carta di identità elettronica', 'certificato di residenza'."
-#: design/plone/contenttypes/interfaces/servizio.py:107
+#: design/plone/contenttypes/interfaces/servizio.py:95
 msgid "cosa_si_ottiene_help"
 msgstr ""
 
 #. Default: "Costi"
-#: design/plone/contenttypes/interfaces/servizio.py:192
+#: design/plone/contenttypes/interfaces/servizio.py:190
 msgid "costi"
 msgstr ""
 
+#. Default: "Costi e vincoli"
+#: design/plone/contenttypes/interfaces/servizio.py:407
+msgid "costi_e_vincoli_label"
+msgstr ""
+
 #. Default: "Descrizione delle condizioni e dei termini economici per completare la procedura di richiesta del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:194
+#: design/plone/contenttypes/interfaces/servizio.py:192
 msgid "costi_help"
 msgstr ""
 
+#. Default: "Costi"
+#: design/plone/contenttypes/behaviors/evento.py:186
+msgid "costi_label"
+msgstr ""
+
 #. Default: "Curriculum vitae"
-#: design/plone/contenttypes/interfaces/persona.py:232
+#: design/plone/contenttypes/interfaces/persona.py:224
 msgid "curriculum_vitae"
 msgstr ""
 
 #. Default: "Curriculum vitae della persona."
-#: design/plone/contenttypes/interfaces/persona.py:234
+#: design/plone/contenttypes/interfaces/persona.py:226
 msgid "curriculum_vitae_help"
 msgstr ""
 
 #. Default: "Data conclusione incarico"
-#: design/plone/contenttypes/interfaces/persona.py:98
+#: design/plone/contenttypes/interfaces/persona.py:57
 msgid "data_conclusione_incarico"
 msgstr ""
 
 #. Default: "Data di conclusione dell'incarico."
-#: design/plone/contenttypes/interfaces/persona.py:101
+#: design/plone/contenttypes/interfaces/persona.py:58
 msgid "data_conclusione_incarico_help"
 msgstr ""
 
 #. Default: "Data e fasi intermedie"
-#: design/plone/contenttypes/interfaces/documento_personale.py:123
+#: design/plone/contenttypes/interfaces/documento_personale.py:115
 msgid "data_e_fasi_intermedie"
 msgstr ""
 
 #. Default: "Data di scadenza"
-#: design/plone/contenttypes/interfaces/documento.py:133
+#: design/plone/contenttypes/interfaces/documento.py:120
 msgid "data_fine"
 msgstr ""
 
 #. Default: "Data di inizio"
-#: design/plone/contenttypes/interfaces/documento.py:127
-#: design/plone/contenttypes/interfaces/documento_personale.py:119
+#: design/plone/contenttypes/interfaces/documento.py:114
+#: design/plone/contenttypes/interfaces/documento_personale.py:111
 msgid "data_inizio"
 msgstr ""
 
 #. Default: "Data insediamento"
-#: design/plone/contenttypes/interfaces/persona.py:88
+#: design/plone/contenttypes/interfaces/persona.py:47
 msgid "data_insediamento"
 msgstr ""
 
 #. Default: "Solo per persona politica: specificare la data di insediamento."
-#: design/plone/contenttypes/interfaces/persona.py:89
+#: design/plone/contenttypes/interfaces/persona.py:48
 msgid "data_insediamento_help"
 msgstr ""
 
 #. Default: "Data del messaggio"
-#: design/plone/contenttypes/interfaces/messaggio.py:14
+#: design/plone/contenttypes/interfaces/messaggio.py:13
 msgid "data_messaggio"
 msgstr ""
 
@@ -1105,13 +1098,13 @@ msgid "data_pagamento"
 msgstr ""
 
 #. Default: "Data del protocollo"
-#: design/plone/contenttypes/interfaces/documento.py:165
+#: design/plone/contenttypes/interfaces/documento.py:149
 #: design/plone/contenttypes/interfaces/documento_personale.py:20
 msgid "data_protocollo"
 msgstr ""
 
 #. Default: "Data di scadenza della procedura"
-#: design/plone/contenttypes/interfaces/messaggio.py:45
+#: design/plone/contenttypes/interfaces/messaggio.py:42
 msgid "data_scadenza_procedura"
 msgstr ""
 
@@ -1130,46 +1123,44 @@ msgstr ""
 msgid "dataset_correlati_label"
 msgstr ""
 
-#. Default: "Date significative"
-#: design/plone/contenttypes/behaviors/evento.py:156
-msgid "date_significative"
+#. Default: "Date dell'evento"
+#: design/plone/contenttypes/behaviors/evento.py:204
+#: design/plone/contenttypes/schema_overrides.py:35
+msgid "date_evento_label"
 msgstr ""
 
 #. Default: "Deleghe"
-#: design/plone/contenttypes/interfaces/persona.py:178
+#: design/plone/contenttypes/interfaces/persona.py:216
 msgid "deleghe"
 msgstr ""
 
 #. Default: "Elenco delle deleghe a capo della persona."
-#: design/plone/contenttypes/interfaces/persona.py:179
+#: design/plone/contenttypes/interfaces/persona.py:217
 msgid "deleghe_help"
 msgstr ""
 
-#. Default: "Descrizione breve"
-#: design/plone/contenttypes/behaviors/luogo.py:30
-msgid "descrizione_breve"
+#. Default: "Descrizione completa"
+#: design/plone/contenttypes/behaviors/luogo.py:42
+msgid "descrizione_completa"
 msgstr ""
 
 #. Default: "Descrizione destinatari"
-#: design/plone/contenttypes/behaviors/evento.py:99
-#: design/plone/contenttypes/interfaces/servizio.py:64
+#: design/plone/contenttypes/behaviors/evento.py:31
 msgid "descrizione_destinatari"
 msgstr ""
 
-#. Default: "Descrizione dei principali interlocutori del servizio: a chi si rivolge e chi può usufruirne."
-#: design/plone/contenttypes/interfaces/servizio.py:68
+#. Default: "Descrizione dei principali interlocutori dell'evento."
+#: design/plone/contenttypes/behaviors/evento.py:33
 msgid "descrizione_destinatari_help"
 msgstr ""
 
 #. Default: "Descrizione estesa"
-#: design/plone/contenttypes/interfaces/documento.py:31
-#: design/plone/contenttypes/interfaces/documento_personale.py:58
-#: design/plone/contenttypes/interfaces/servizio.py:55
+#: design/plone/contenttypes/behaviors/descrizione_estesa.py:17
 msgid "descrizione_estesa"
 msgstr ""
 
-#. Default: "Descrizione dettagliata e completa del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:57
+#. Default: "Descrizione dettagliata e completa."
+#: design/plone/contenttypes/behaviors/descrizione_estesa.py:19
 msgid "descrizione_estesa_help"
 msgstr ""
 
@@ -1179,22 +1170,47 @@ msgid "distribuzione"
 msgstr ""
 
 #. Default: "Documenti allegati"
-#: design/plone/contenttypes/interfaces/messaggio.py:61
+#: design/plone/contenttypes/interfaces/messaggio.py:57
 msgid "documenti_allegati"
 msgstr ""
 
+#. Default: "Documenti"
+#: design/plone/contenttypes/interfaces/servizio.py:430
+msgid "documenti_label"
+msgstr ""
+
+#. Default: "Dove"
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:65
+msgid "dove_label"
+msgstr ""
+
+#. Default: "Dove rivolgersi: informazioni aggiuntive"
+#: design/plone/contenttypes/interfaces/servizio.py:147
+msgid "dove_rivolgersi_extra"
+msgstr ""
+
+#. Default: "Indicare eventuali informazioni aggiuntive riguardo al dove rivolgersi per questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:151
+msgid "dove_rivolgersi_extra_help"
+msgstr ""
+
+#. Default: "Seleziona una lista delle sedi e dei luoghi in cui è presente questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:139
+msgid "dove_rivolgersi_help"
+msgstr ""
+
 #. Default: "Elementi di interesse"
-#: design/plone/contenttypes/behaviors/luogo.py:38
+#: design/plone/contenttypes/behaviors/luogo.py:63
 msgid "elementi_di_interesse"
 msgstr ""
 
 #. Default: "Indirizzo email"
-#: design/plone/contenttypes/interfaces/persona.py:216
+#: design/plone/contenttypes/interfaces/persona.py:82
 msgid "email"
 msgstr ""
 
 #. Default: "Contatto mail della persona."
-#: design/plone/contenttypes/interfaces/persona.py:217
+#: design/plone/contenttypes/interfaces/persona.py:83
 msgid "email_help"
 msgstr ""
 
@@ -1203,23 +1219,8 @@ msgstr ""
 msgid "esito"
 msgstr ""
 
-#. Default: "Evento genitore"
-#: design/plone/contenttypes/behaviors/evento.py:68
-msgid "evento_genitore"
-msgstr ""
-
-#. Default: "Fasi e scadenze"
-#: design/plone/contenttypes/interfaces/servizio.py:172
-msgid "fasi_scadenze"
-msgstr ""
-
-#. Default: "Prevedere una data di scadenza del servizio. Se il servizio è diviso in fasi, descriverne modalità e tempistiche."
-#: design/plone/contenttypes/interfaces/servizio.py:174
-msgid "fasi_scadenze_help"
-msgstr ""
-
 #. Default: "Foto da mostrare della persona; la dimensione suggerita è 180x100 px"
-#: design/plone/contenttypes/interfaces/persona.py:20
+#: design/plone/contenttypes/interfaces/persona.py:21
 msgid "foto_persona_help"
 msgstr ""
 
@@ -1233,8 +1234,78 @@ msgstr ""
 msgid "geolocation_field_validator_label"
 msgstr ""
 
+#. Default: "Indicare l'eventuale circoscrizione in cui si trova questo luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:33
+msgid "help_circoscrizione"
+msgstr ""
+
+#. Default: "Indicare una descrizione completa, inserendo tutte le informazioni rilevanti relative al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:43
+msgid "help_descrizione_completa"
+msgstr ""
+
+#. Default: "Indicare eventuali elementi di interesse relativi al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:64
+msgid "help_elementi_di_interesse"
+msgstr ""
+
+#. Default: "Indicare tutte le informazioni relative alla modalità di accesso al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:73
+msgid "help_modalita_accesso"
+msgstr ""
+
+#. Default: "Indicare, se esiste, un nome alternativo per il luogo; questo sarà mostrato tra parentesi affiancato al titolo della scheda"
+#: design/plone/contenttypes/behaviors/luogo.py:53
+msgid "help_nome_alternativo"
+msgstr ""
+
+#. Default: "Indicare eventuali orari di accesso al pubblico"
+#: design/plone/contenttypes/behaviors/luogo.py:105
+msgid "help_orario_pubblico"
+msgstr ""
+
+#. Default: "Indicare l'eventuale quartiere in cui si trova questo luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:24
+msgid "help_quartiere"
+msgstr ""
+
+#. Default: "Indicare un indirizzo mail per poter contattare i referenti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:95
+msgid "help_riferimento_mail_luogo"
+msgstr ""
+
+#. Default: "Indicare un indirizzo mail per poter contattare i referenti della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:170
+msgid "help_riferimento_mail_struttura"
+msgstr ""
+
+#. Default: "Indicare un riferimento telefonico per poter contattare i referenti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:85
+msgid "help_riferimento_telefonico_luogo"
+msgstr ""
+
+#. Default: "Indicare il riferimento telefonico per poter contattare i referenti della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:157
+msgid "help_riferimento_telefonico_struttura"
+msgstr ""
+
+#. Default: "Indicare un indirizzo web utile per ottenere i contatti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:180
+msgid "help_riferimento_web"
+msgstr ""
+
+#. Default: "Icona"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:17
+msgid "icona"
+msgstr ""
+
+#. Default: "Puoi selezionare un’icona fra quelle proposte nel menu a tendina oppure puoi scrivere/incollare nel campo di testo il nome di un’icona di fontawsome 5"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:18
+msgid "icona_help"
+msgstr ""
+
 #. Default: "Identificativo"
-#: design/plone/contenttypes/interfaces/servizio.py:341
+#: design/plone/contenttypes/interfaces/servizio.py:307
 msgid "identificativo"
 msgstr ""
 
@@ -1244,24 +1315,14 @@ msgid "identificativo_documento"
 msgstr ""
 
 #. Default: "Eventuale codice identificativo del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:343
+#: design/plone/contenttypes/interfaces/servizio.py:309
 msgid "identificativo_help"
 msgstr ""
 
-#. Default: "Identificativo"
-#: design/plone/contenttypes/behaviors/luogo.py:106
-msgid "identificativo_mibac"
-msgstr ""
-
-#. Default: "Identifier"
-#: design/plone/contenttypes/behaviors/evento.py:46
-msgid "identifier"
-msgstr ""
-
 #. Default: "Immagine"
-#: design/plone/contenttypes/behaviors/evento.py:54
 #: design/plone/contenttypes/interfaces/documento.py:23
 #: design/plone/contenttypes/interfaces/documento_personale.py:24
+#: design/plone/contenttypes/interfaces/persona.py:19
 msgid "immagine"
 msgstr ""
 
@@ -1270,33 +1331,45 @@ msgstr ""
 msgid "importo_pagato"
 msgstr ""
 
-#. Default: "Indirizzo"
-#: design/plone/contenttypes/behaviors/evento.py:142
-msgid "indirizzo"
+#. Default: "Inserisci eventuale testo informativo che verrà mostrato in testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:23
+msgid "info_testata_help"
+msgstr ""
+
+#. Default: "Informazioni aggiuntive per la testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:18
+msgid "info_testata_label"
 msgstr ""
 
 #. Default: "Ulteriori informazioni"
-#: design/plone/contenttypes/interfaces/documento_personale.py:143
+#: design/plone/contenttypes/interfaces/documento_personale.py:134
 msgid "informazioni"
 msgstr ""
 
 #. Default: "Informazioni di contatto"
-#: design/plone/contenttypes/interfaces/persona.py:221
+#: design/plone/contenttypes/interfaces/persona.py:88
 msgid "informazioni_di_contatto"
 msgstr ""
 
 #. Default: "Altre informazioni di contatto."
-#: design/plone/contenttypes/interfaces/persona.py:224
+#: design/plone/contenttypes/interfaces/persona.py:89
 msgid "informazioni_di_contatto_help"
 msgstr ""
 
-#. Default: "Introduzione"
-#: design/plone/contenttypes/behaviors/evento.py:92
-msgid "introduzione"
+#. Default: "Ulteriori informazioni"
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:29
+#: design/plone/contenttypes/behaviors/evento.py:199
+#: design/plone/contenttypes/schema_overrides.py:54
+msgid "informazioni_label"
+msgstr ""
+
+#. Default: "Categorization"
+#: design/plone/contenttypes/behaviors/argomenti.py:65
+msgid "label_schema_categorization"
 msgstr ""
 
 #. Default: "Selezionare la lista di strutture e/o uffici collegati a questa unità organizzativa."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:28
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:29
 msgid "legami_con_altre_strutture_help"
 msgstr ""
 
@@ -1306,30 +1379,40 @@ msgid "licenza"
 msgstr ""
 
 #. Default: "Licenza di distribuzione"
-#: design/plone/contenttypes/interfaces/documento.py:97
-#: design/plone/contenttypes/interfaces/documento_personale.py:95
+#: design/plone/contenttypes/interfaces/documento.py:85
+#: design/plone/contenttypes/interfaces/documento_personale.py:89
 msgid "licenza_distribuzione"
 msgstr ""
 
 #. Default: "Parte del life event"
-#: design/plone/contenttypes/interfaces/documento.py:177
-#: design/plone/contenttypes/interfaces/servizio.py:307
+#: design/plone/contenttypes/interfaces/documento.py:156
+#: design/plone/contenttypes/interfaces/servizio.py:273
 msgid "life_event"
 msgstr ""
 
 #. Default: "Collegamento tra il servizio e un evento della vita di una persona o di un'impresa. Ad esempio: il servizio 'Anagrafe' è collegato alla nascita di un bambino"
-#: design/plone/contenttypes/interfaces/servizio.py:308
+#: design/plone/contenttypes/interfaces/servizio.py:274
 msgid "life_event_help"
 msgstr ""
 
 #. Default: "Link a siti esterni"
-#: design/plone/contenttypes/interfaces/servizio.py:294
+#: design/plone/contenttypes/interfaces/servizio.py:260
 msgid "link_siti_esterni"
 msgstr ""
 
 #. Default: "Eventuali collegamenti a pagine web, siti, servizi esterni all'ambito Comunale utili all'erogazione del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:296
+#: design/plone/contenttypes/interfaces/servizio.py:262
 msgid "link_siti_esterni_help"
+msgstr ""
+
+#. Default: "Link utili"
+#: design/plone/contenttypes/interfaces/servizio.py:435
+msgid "link_utili_label"
+msgstr ""
+
+#. Default: "Luoghi dell'evento"
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:56
+msgid "luoghi_correlati_evento_label"
 msgstr ""
 
 #. Default: "Seleziona una lista di luoghi citati."
@@ -1342,13 +1425,8 @@ msgstr ""
 msgid "luoghi_correlati_label"
 msgstr ""
 
-#. Default: "Luogo dell'evento"
-#: design/plone/contenttypes/behaviors/evento.py:125
-msgid "luogo_evento"
-msgstr ""
-
 #. Default: "Modalita' di accesso"
-#: design/plone/contenttypes/behaviors/luogo.py:43
+#: design/plone/contenttypes/behaviors/luogo.py:72
 msgid "modalita_accesso"
 msgstr ""
 
@@ -1357,33 +1435,43 @@ msgstr ""
 msgid "modalita_pagamento"
 msgstr ""
 
-#. Default: "Motivo dello stato del servizio nel caso non sia attivo"
-#: design/plone/contenttypes/interfaces/servizio.py:33
-msgid "motivo_stato_servizio"
+#. Default: "Seleziona se mostrare o meno la navigazione laterale nella testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:43
+msgid "mostra_navigazione_help"
+msgstr ""
+
+#. Default: "Mostra la navigazione"
+#: design/plone/contenttypes/behaviors/info_testata.py:40
+msgid "mostra_navigazione_label"
 msgstr ""
 
 #. Default: "Descrizione del motivo per cui il servizio non è attivo."
-#: design/plone/contenttypes/interfaces/servizio.py:38
+#: design/plone/contenttypes/interfaces/servizio.py:48
 msgid "motivo_stato_servizio_help"
 msgstr ""
 
+#. Default: "Motivo dello stato del servizio nel caso non sia attivo"
+#: design/plone/contenttypes/interfaces/servizio.py:43
+msgid "motivo_stato_servizio_label"
+msgstr ""
+
 #. Default: "Nome alternativo"
-#: design/plone/contenttypes/behaviors/luogo.py:34
+#: design/plone/contenttypes/behaviors/luogo.py:52
 msgid "nome_alternativo"
 msgstr ""
 
 #. Default: "Seleziona una lista di notizie correlate a questa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:63
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:62
 msgid "notizie_correlate_help"
 msgstr ""
 
 #. Default: "Notizie correlate"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:62
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:61
 msgid "notizie_correlate_label"
 msgstr ""
 
 #. Default: "Numero progressivo del comunicato stampa"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:30
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:29
 msgid "numero_progressivo_cs_label"
 msgstr ""
 
@@ -1394,48 +1482,78 @@ msgid "numero_protocollo"
 msgstr ""
 
 #. Default: "Oggetto"
-#: design/plone/contenttypes/interfaces/documento_personale.py:52
+#: design/plone/contenttypes/interfaces/documento_personale.py:49
 msgid "oggetto"
 msgstr ""
 
-#. Default: "Orari"
-#: design/plone/contenttypes/behaviors/evento.py:160
+#. Default: "Informazioni sugli orari"
+#: design/plone/contenttypes/behaviors/evento.py:82
 msgid "orari"
 msgstr ""
 
+#. Default: "Informazioni sugli orari di svolgimento dell'evento."
+#: design/plone/contenttypes/behaviors/evento.py:84
+msgid "orari_help"
+msgstr ""
+
 #. Default: "Orario per il pubblico"
-#: design/plone/contenttypes/behaviors/luogo.py:59
+#: design/plone/contenttypes/behaviors/luogo.py:104
 msgid "orario_pubblico"
 msgstr ""
 
 #. Default: "Organizzato da"
-#: design/plone/contenttypes/behaviors/evento.py:167
+#: design/plone/contenttypes/behaviors/evento.py:102
 msgid "organizzato_da_esterno"
 msgstr ""
 
+#. Default: "Se l'evento non è organizzato direttamente dal comune, indicare l'organizzatore."
+#: design/plone/contenttypes/behaviors/evento.py:104
+msgid "organizzato_da_esterno_help"
+msgstr ""
+
+#. Default: "Se l'evento è organizzato direttamente dal comune, indicare l'ufficio/ente organizzatore."
+#: design/plone/contenttypes/behaviors/evento.py:128
+msgid "organizzato_da_interno_help"
+msgstr ""
+
 #. Default: "Organizzazione di riferimento"
-#: design/plone/contenttypes/interfaces/persona.py:35
+#: design/plone/contenttypes/interfaces/persona.py:96
 msgid "organizzazione_riferimento"
 msgstr ""
 
 #. Default: "Seleziona una lista di organizzazioni a cui la persona appartiene."
-#: design/plone/contenttypes/interfaces/persona.py:39
+#: design/plone/contenttypes/interfaces/persona.py:99
 msgid "organizzazione_riferimento_help"
 msgstr ""
 
+#. Default: "Partecipanti"
+#: design/plone/contenttypes/behaviors/evento.py:183
+msgid "partecipanti_label"
+msgstr ""
+
 #. Default: "Patrocinato da"
-#: design/plone/contenttypes/behaviors/evento.py:263
+#: design/plone/contenttypes/behaviors/evento.py:172
 msgid "patrocinato_da"
 msgstr ""
 
+#. Default: "Indicare l'ente che supporta l'evento, se presente."
+#: design/plone/contenttypes/behaviors/evento.py:174
+msgid "patrocinato_da_help"
+msgstr ""
+
+#. Default: "Elenco delle persone dell'amministrazione che parteciperanno all'evento."
+#: design/plone/contenttypes/behaviors/evento.py:46
+msgid "persone_amministrazione_help"
+msgstr ""
+
 #. Default: "Seleziona la lista delle persone che compongono la struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:128
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:90
 msgid "persone_struttura_help"
 msgstr ""
 
 #. Default: "Pratica associata"
 #: design/plone/contenttypes/interfaces/documento_personale.py:28
-#: design/plone/contenttypes/interfaces/messaggio.py:37
+#: design/plone/contenttypes/interfaces/messaggio.py:35
 msgid "pratica_associata"
 msgstr ""
 
@@ -1444,106 +1562,120 @@ msgstr ""
 msgid "pratica_associata_ricevuta"
 msgstr ""
 
+#. Default: "Prenota un appuntamento"
+#: design/plone/contenttypes/interfaces/servizio.py:160
+msgid "prenota_appuntamento"
+msgstr ""
+
+#. Default: "Se è possibile prenotare un'appuntamento, indicare le informazioni necessarie e il collegamento al servizio di prenotazione appuntamenti del Comune."
+#: design/plone/contenttypes/interfaces/servizio.py:161
+msgid "prenota_appuntamento_help"
+msgstr ""
+
 #. Default: "Prezzo"
-#: design/plone/contenttypes/behaviors/evento.py:164
+#: design/plone/contenttypes/behaviors/evento.py:92
 msgid "prezzo"
 msgstr ""
 
+#. Default: "Indicare il prezzo dell'evento, se presente, specificando se esistono formati diversi."
+#: design/plone/contenttypes/behaviors/evento.py:94
+msgid "prezzo_help"
+msgstr ""
+
 #. Default: "Procedure collegate all'esito"
-#: design/plone/contenttypes/interfaces/servizio.py:116
+#: design/plone/contenttypes/interfaces/servizio.py:104
 msgid "procedure_collegate"
 msgstr ""
 
 #. Default: "Indicare cosa deve fare l'utente del servizio per conoscere l'esito della procedura, e dove eventualmente poter ritirare l'esito."
-#: design/plone/contenttypes/interfaces/servizio.py:120
+#: design/plone/contenttypes/interfaces/servizio.py:106
 msgid "procedure_collegate_help"
 msgstr ""
 
 #. Default: "Protocollo"
-#: design/plone/contenttypes/interfaces/documento.py:161
+#: design/plone/contenttypes/interfaces/documento.py:145
 #: design/plone/contenttypes/interfaces/documento_personale.py:16
 msgid "protocollo"
 msgstr ""
 
 #. Default: "Quartiere"
-#: design/plone/contenttypes/behaviors/evento.py:146
-#: design/plone/contenttypes/behaviors/luogo.py:22
+#: design/plone/contenttypes/behaviors/luogo.py:23
 msgid "quartiere"
 msgstr ""
 
 #. Default: "Responsabile di"
-#: design/plone/contenttypes/interfaces/persona.py:63
+#: design/plone/contenttypes/interfaces/persona.py:123
 msgid "responsabile_di"
 msgstr ""
 
 #. Default: "Seleziona una lista di organizzazioni di cui la persona è responsabile."
-#: design/plone/contenttypes/interfaces/persona.py:64
+#: design/plone/contenttypes/interfaces/persona.py:124
 msgid "responsabile_di_help"
 msgstr ""
 
 #. Default: "Selezionare il/i responsabile/i della struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:60
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:45
 msgid "responsabile_help"
 msgstr ""
 
+#. Default: "Seleziona se mostrare o meno il campo di ricerca in testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:33
+msgid "ricerca_in_testata_help"
+msgstr ""
+
+#. Default: "Ricerca in testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:30
+msgid "ricerca_in_testata_label"
+msgstr ""
+
 #. Default: "Riferimenti normativi"
-#: design/plone/contenttypes/interfaces/documento.py:156
-#: design/plone/contenttypes/interfaces/documento_personale.py:148
+#: design/plone/contenttypes/interfaces/documento.py:140
+#: design/plone/contenttypes/interfaces/documento_personale.py:138
 msgid "riferimenti_normativi"
 msgstr ""
 
 #. Default: "Riferimento mail luogo"
-#: design/plone/contenttypes/behaviors/luogo.py:54
+#: design/plone/contenttypes/behaviors/luogo.py:94
 msgid "riferimento_mail_luogo"
 msgstr ""
 
-#. Default: "Riferimento mail struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:81
+#. Default: "Riferimento mail della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:166
 msgid "riferimento_mail_struttura"
 msgstr ""
 
-#. Default: "Riferimento pec"
-#: design/plone/contenttypes/behaviors/luogo.py:124
-msgid "riferimento_pec"
-msgstr ""
-
 #. Default: "Riferimento telefonico luogo"
-#: design/plone/contenttypes/behaviors/luogo.py:47
+#: design/plone/contenttypes/behaviors/luogo.py:82
 msgid "riferimento_telefonico_luogo"
 msgstr ""
 
-#. Default: "Riferimento telefonico struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:73
+#. Default: "Riferimento telefonico della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:153
 msgid "riferimento_telefonico_struttura"
 msgstr ""
 
 #. Default: "Riferimento sito web"
-#: design/plone/contenttypes/behaviors/luogo.py:89
+#: design/plone/contenttypes/behaviors/luogo.py:179
 msgid "riferimento_web"
 msgstr ""
 
 #. Default: "Ruolo"
-#: design/plone/contenttypes/interfaces/persona.py:26
+#: design/plone/contenttypes/interfaces/persona.py:39
 msgid "ruolo"
 msgstr ""
 
 #. Default: "Descrizione testuale del ruolo di questa persona."
-#: design/plone/contenttypes/interfaces/persona.py:27
+#: design/plone/contenttypes/interfaces/persona.py:40
 msgid "ruolo_help"
 msgstr ""
 
-#. Default: "Seleziona la lista delle sedi e dei luoghi collegati a questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:391
-msgid "sedi_e_luoghi_help"
-msgstr ""
-
 #. Default: "Seleziona una lista delle sedi di questa struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:183
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:104
 msgid "sedi_help"
 msgstr ""
 
 #. Default: "Seleziona la lista dei servizi collegati a questo."
-#: design/plone/contenttypes/interfaces/servizio.py:368
+#: design/plone/contenttypes/interfaces/servizio.py:322
 msgid "servizi_collegati_help"
 msgstr ""
 
@@ -1558,7 +1690,7 @@ msgid "servizi_correlati_label"
 msgstr ""
 
 #. Default: "Servizio che genera il documento"
-#: design/plone/contenttypes/interfaces/documento_personale.py:33
+#: design/plone/contenttypes/interfaces/documento_personale.py:32
 msgid "servizio_origine"
 msgstr ""
 
@@ -1573,23 +1705,23 @@ msgid "servizio_origine_ricevuta"
 msgstr ""
 
 #. Default: "Settore merceologico"
-#: design/plone/contenttypes/interfaces/servizio.py:331
+#: design/plone/contenttypes/interfaces/servizio.py:297
 msgid "settore_merceologico"
 msgstr ""
 
 #. Default: "Classificazione del servizio basata su catalogo dei servizi (Classificazione NACE)."
-#: design/plone/contenttypes/interfaces/servizio.py:333
+#: design/plone/contenttypes/interfaces/servizio.py:299
 msgid "settore_merceologico_help"
 msgstr ""
 
-#. Default: "Sottotitolo"
-#: design/plone/contenttypes/interfaces/servizio.py:45
-msgid "sottotitolo"
+#. Default: "Indica un eventuale sottotitolo/titolo alternativo per questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:22
+msgid "sottotitolo_help"
 msgstr ""
 
-#. Default: "Sponsor"
-#: design/plone/contenttypes/behaviors/evento.py:267
-msgid "sponsor"
+#. Default: "Sottotitolo"
+#: design/plone/contenttypes/interfaces/servizio.py:21
+msgid "sottotitolo_label"
 msgstr ""
 
 #. Default: "Stampa ricevuta"
@@ -1602,58 +1734,68 @@ msgstr ""
 msgid "stato_pratica"
 msgstr ""
 
-#. Default: "Servizio non attivo"
-#: design/plone/contenttypes/interfaces/servizio.py:24
-msgid "stato_servizio"
-msgstr ""
-
 #. Default: "Indica se il servizio è effettivamente fruibile."
-#: design/plone/contenttypes/interfaces/servizio.py:26
+#: design/plone/contenttypes/interfaces/servizio.py:36
 msgid "stato_servizio_help"
 msgstr ""
 
+#. Default: "Servizio non attivo"
+#: design/plone/contenttypes/interfaces/servizio.py:34
+msgid "stato_servizio_label"
+msgstr ""
+
 #. Default: "Struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:63
+#: design/plone/contenttypes/behaviors/luogo.py:143
 msgid "struttura_responsabile"
 msgstr ""
 
+#. Default: "Struttura responsabile del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:113
+msgid "struttura_responsabile_correlati"
+msgstr ""
+
+#. Default: "Indicare la struttura responsabile del luogo qualora sia fra unità organizzative del comune inserite nel sito; altrimenti compilare i campi testuali relativi alla struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:117
+msgid "struttura_responsabile_correlati_help"
+msgstr ""
+
 #. Default: "Nome/link al sito web della struttura che gestisce il luogo, se questa non è comunale."
-#: design/plone/contenttypes/behaviors/luogo.py:65
+#: design/plone/contenttypes/behaviors/luogo.py:145
 msgid "struttura_responsabile_help"
 msgstr ""
 
-#. Default: "Indica un eventuale sottotitolo/titolo alternativo per questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:46
-msgid "subtitle_help"
+#. Default: "Seleziona la lista delle strutture politiche coinvolte."
+#: design/plone/contenttypes/behaviors/strutture_correlate.py:25
+msgid "strutture_politiche_help"
 msgstr ""
 
 #. Default: "Evento supportato da"
-#: design/plone/contenttypes/behaviors/evento.py:221
+#: design/plone/contenttypes/behaviors/evento.py:146
 msgid "supportato_da"
 msgstr ""
 
-#. Default: "Tassonomia argomenti"
-#: design/plone/contenttypes/behaviors/evento.py:58
-msgid "tassonomia_argomenti"
+#. Default: "Se l'evento è organizzato direttamente dal comune, indicare l'ufficio/ente che supporta l'evento."
+#: design/plone/contenttypes/behaviors/evento.py:153
+msgid "supportato_da_help"
 msgstr ""
 
 #. Default: "Seleziona una lista di argomenti d'interesse per questo contenuto."
-#: design/plone/contenttypes/behaviors/argomenti.py:20
+#: design/plone/contenttypes/behaviors/argomenti.py:21
 msgid "tassonomia_argomenti_help"
 msgstr ""
 
 #. Default: "Tassonomia argomenti"
-#: design/plone/contenttypes/behaviors/argomenti.py:19
+#: design/plone/contenttypes/behaviors/argomenti.py:20
 msgid "tassonomia_argomenti_label"
 msgstr ""
 
 #. Default: "Numero di telefono"
-#: design/plone/contenttypes/interfaces/persona.py:208
+#: design/plone/contenttypes/interfaces/persona.py:76
 msgid "telefono"
 msgstr ""
 
 #. Default: "Contatto telefonico della persona."
-#: design/plone/contenttypes/interfaces/persona.py:209
+#: design/plone/contenttypes/interfaces/persona.py:77
 msgid "telefono_help"
 msgstr ""
 
@@ -1662,8 +1804,28 @@ msgstr ""
 msgid "temi"
 msgstr ""
 
+#. Default: "Tempi e scadenze"
+#: design/plone/contenttypes/interfaces/servizio.py:171
+msgid "tempi_e_scadenze"
+msgstr ""
+
+#. Default: "Descrivere le informazioni dettagliate riguardo eventuali tempi e scadenze di questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:173
+msgid "tempi_e_scadenze_help"
+msgstr ""
+
+#. Default: "Tempi e scadenze"
+#: design/plone/contenttypes/interfaces/servizio.py:413
+msgid "tempi_e_scadenze_label"
+msgstr ""
+
+#. Default: "Testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:51
+msgid "testata_fieldset_label"
+msgstr ""
+
 #. Default: "Tipologia documento"
-#: design/plone/contenttypes/interfaces/messaggio.py:54
+#: design/plone/contenttypes/interfaces/messaggio.py:50
 msgid "tipologia_documento"
 msgstr ""
 
@@ -1678,22 +1840,22 @@ msgid "tipologia_notizia_label"
 msgstr ""
 
 #. Default: "Tipologia organizzazione"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:79
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:54
 msgid "tipologia_organizzazione"
 msgstr ""
 
 #. Default: "Specificare la tipologia di organizzazione: politica, amminsitrativa o di altro tipo."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:85
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:57
 msgid "tipologia_organizzazione_help"
 msgstr ""
 
 #. Default: "Tipologia persona"
-#: design/plone/contenttypes/interfaces/persona.py:187
+#: design/plone/contenttypes/interfaces/persona.py:28
 msgid "tipologia_persona"
 msgstr ""
 
 #. Default: "Seleziona la tipologia di persona: politica, amministrativa o di altro tipo."
-#: design/plone/contenttypes/interfaces/persona.py:188
+#: design/plone/contenttypes/interfaces/persona.py:29
 msgid "tipologia_persona_help"
 msgstr ""
 
@@ -1703,22 +1865,22 @@ msgid "titolare"
 msgstr ""
 
 #. Default: "Ufficio responsabile del documento"
-#: design/plone/contenttypes/interfaces/documento.py:37
+#: design/plone/contenttypes/interfaces/documento.py:32
 msgid "ufficio_responsabile"
 msgstr ""
 
 #. Default: "Ufficio responsabile"
-#: design/plone/contenttypes/interfaces/documento_personale.py:71
+#: design/plone/contenttypes/interfaces/documento_personale.py:63
 msgid "ufficio_responsabile_documento_personale"
 msgstr ""
 
-#. Default: "Ufficio resposabile"
-#: design/plone/contenttypes/interfaces/servizio.py:222
+#. Default: "Ufficio responsabile"
+#: design/plone/contenttypes/interfaces/servizio.py:219
 msgid "ufficio_responsabile_erogazione"
 msgstr ""
 
 #. Default: "Seleziona l'ufficio responsabile dell'erogazione di questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:223
+#: design/plone/contenttypes/interfaces/servizio.py:220
 msgid "ufficio_responsabile_help"
 msgstr ""
 
@@ -1728,41 +1890,46 @@ msgid "ufficio_riferimento"
 msgstr ""
 
 #. Default: "Ulteriori informazioni"
-#: design/plone/contenttypes/behaviors/additional_help_infos.py:17
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:19
 msgid "ulteriori_informazioni"
 msgstr ""
 
 #. Default: "Ulteriori informazioni non contemplate dai campi precedenti."
-#: design/plone/contenttypes/behaviors/additional_help_infos.py:18
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:20
 msgid "ulteriori_informazioni_help"
 msgstr ""
 
+#. Default: "Unità amministrativa responsabile"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:28
+msgid "unita_amministrativa_responsabile"
+msgstr ""
+
+#. Default: "Seleziona la lista delle unità amministrative responsabili di questo argomento."
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:38
+msgid "unita_amministrativa_responsabile_help"
+msgstr ""
+
 #. Default: "Informazioni"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:167
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:98
 msgid "unteriori_informazioni"
 msgstr ""
 
-#. Default: "Eventuali contatti di supporto all'utente."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:174
-msgid "uo_box_aiuto_help"
-msgstr ""
-
 #. Default: "Descrizione dei compiti assegnati alla struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:18
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:19
 msgid "uo_competenze_help"
 msgstr ""
 
 #. Default: "Eventuali informazioni di contatto generiche"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:207
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:116
 msgid "uo_contact_info_description"
 msgstr ""
 
 #. Default: "Vincoli"
-#: design/plone/contenttypes/interfaces/servizio.py:202
+#: design/plone/contenttypes/interfaces/servizio.py:200
 msgid "vincoli"
 msgstr ""
 
 #. Default: "Descrizione degli eventuali vincoli presenti."
-#: design/plone/contenttypes/interfaces/servizio.py:204
+#: design/plone/contenttypes/interfaces/servizio.py:202
 msgid "vincoli_help"
 msgstr ""

--- a/src/design/plone/contenttypes/locales/design.plone.contenttypes.pot
+++ b/src/design/plone/contenttypes/locales/design.plone.contenttypes.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-04 09:16+0000\n"
+"POT-Creation-Date: 2020-09-04 10:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -200,7 +200,7 @@ msgstr ""
 msgid "Dataset collegato"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:82
+#: design/plone/contenttypes/behaviors/configure.zcml:73
 msgid "Dataset correlati"
 msgstr ""
 
@@ -212,7 +212,7 @@ msgstr ""
 msgid "Denuncia crimini"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:130
+#: design/plone/contenttypes/behaviors/configure.zcml:121
 msgid "Descrizione estesa"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Indicare le dimensioni delle lead image dei contenuti"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:141
+#: design/plone/contenttypes/behaviors/configure.zcml:132
 msgid "Info per la testata"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "Leggere"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:63
+#: design/plone/contenttypes/behaviors/configure.zcml:54
 msgid "Luoghi correlati"
 msgstr ""
 
@@ -442,7 +442,7 @@ msgid "Nazione"
 msgstr ""
 
 #. Default: "Nome e cognome"
-#: design/plone/contenttypes/restapi/services/types/get.py:106
+#: design/plone/contenttypes/restapi/services/types/get.py:96
 msgid "Nome e Cognome"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Servizi collegati"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:92
+#: design/plone/contenttypes/behaviors/configure.zcml:83
 msgid "Servizi correlati"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgstr ""
 msgid "Struttura responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:102
+#: design/plone/contenttypes/behaviors/configure.zcml:93
 msgid "Strutture correlate"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "Ufficio responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:112
+#: design/plone/contenttypes/behaviors/configure.zcml:103
 msgid "Ulteriori campi aiuto testuali"
 msgstr ""
 
@@ -990,9 +990,9 @@ msgid "copertura_geografica_label"
 msgstr ""
 
 #. Default: "Contenuti collegati"
-#: design/plone/contenttypes/behaviors/argomenti.py:44
 #: design/plone/contenttypes/behaviors/dataset_correlati.py:40
 #: design/plone/contenttypes/behaviors/luoghi_correlati.py:38
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:100
 msgid "correlati_label"
 msgstr ""
 
@@ -1361,11 +1361,6 @@ msgstr ""
 #: design/plone/contenttypes/behaviors/evento.py:199
 #: design/plone/contenttypes/schema_overrides.py:54
 msgid "informazioni_label"
-msgstr ""
-
-#. Default: "Categorization"
-#: design/plone/contenttypes/behaviors/argomenti.py:65
-msgid "label_schema_categorization"
 msgstr ""
 
 #. Default: "Selezionare la lista di strutture e/o uffici collegati a questa unità organizzativa."

--- a/src/design/plone/contenttypes/locales/en/LC_MESSAGES/design.plone.contenttypes.po
+++ b/src/design/plone/contenttypes/locales/en/LC_MESSAGES/design.plone.contenttypes.po
@@ -193,7 +193,7 @@ msgstr ""
 msgid "Dataset collegato"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:82
+#: design/plone/contenttypes/behaviors/configure.zcml:73
 msgid "Dataset correlati"
 msgstr ""
 
@@ -205,7 +205,7 @@ msgstr ""
 msgid "Denuncia crimini"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:130
+#: design/plone/contenttypes/behaviors/configure.zcml:121
 msgid "Descrizione estesa"
 msgstr ""
 
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Indicare le dimensioni delle lead image dei contenuti"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:141
+#: design/plone/contenttypes/behaviors/configure.zcml:132
 msgid "Info per la testata"
 msgstr ""
 
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Leggere"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:63
+#: design/plone/contenttypes/behaviors/configure.zcml:54
 msgid "Luoghi correlati"
 msgstr ""
 
@@ -435,7 +435,7 @@ msgid "Nazione"
 msgstr ""
 
 #. Default: "Nome e cognome"
-#: design/plone/contenttypes/restapi/services/types/get.py:106
+#: design/plone/contenttypes/restapi/services/types/get.py:96
 msgid "Nome e Cognome"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Servizi collegati"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:92
+#: design/plone/contenttypes/behaviors/configure.zcml:83
 msgid "Servizi correlati"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Struttura responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:102
+#: design/plone/contenttypes/behaviors/configure.zcml:93
 msgid "Strutture correlate"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Ufficio responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:112
+#: design/plone/contenttypes/behaviors/configure.zcml:103
 msgid "Ulteriori campi aiuto testuali"
 msgstr ""
 
@@ -983,9 +983,9 @@ msgid "copertura_geografica_label"
 msgstr ""
 
 #. Default: "Contenuti collegati"
-#: design/plone/contenttypes/behaviors/argomenti.py:44
 #: design/plone/contenttypes/behaviors/dataset_correlati.py:40
 #: design/plone/contenttypes/behaviors/luoghi_correlati.py:38
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:100
 msgid "correlati_label"
 msgstr ""
 
@@ -1354,11 +1354,6 @@ msgstr ""
 #: design/plone/contenttypes/behaviors/evento.py:199
 #: design/plone/contenttypes/schema_overrides.py:54
 msgid "informazioni_label"
-msgstr ""
-
-#. Default: "Categorization"
-#: design/plone/contenttypes/behaviors/argomenti.py:65
-msgid "label_schema_categorization"
 msgstr ""
 
 #. Default: "Selezionare la lista di strutture e/o uffici collegati a questa unità organizzativa."

--- a/src/design/plone/contenttypes/locales/en/LC_MESSAGES/design.plone.contenttypes.po
+++ b/src/design/plone/contenttypes/locales/en/LC_MESSAGES/design.plone.contenttypes.po
@@ -18,11 +18,11 @@ msgstr ""
 msgid "Abitazione"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:42
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:37
 msgid "Accesso al trasporto pubblico"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:70
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:62
 msgid "Accesso luoghi della cultura"
 msgstr ""
 
@@ -66,32 +66,27 @@ msgstr ""
 msgid "Anziano"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:254
+#: design/plone/contenttypes/interfaces/servizio.py:241
 msgid "Area"
-msgstr ""
-
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:20
-msgid "Area di appartenenza"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:53
 msgid "Area di parcheggio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:63
+#: design/plone/contenttypes/interfaces/documento.py:52
 msgid "Area responsabile"
 msgstr ""
 
 #: design/plone/contenttypes/behaviors/configure.zcml:45
-#: design/plone/contenttypes/behaviors/evento.py:61
 msgid "Argomenti"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:41
-msgid "Assessorati di riferimento"
+#: design/plone/contenttypes/behaviors/argomenti.py:27
+msgid "Argomenti correlati"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:98
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:70
 msgid "Assessore di riferimento"
 msgstr ""
 
@@ -107,8 +102,8 @@ msgstr ""
 msgid "Atto normativo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:82
-#: design/plone/contenttypes/interfaces/documento_personale.py:89
+#: design/plone/contenttypes/interfaces/documento.py:70
+#: design/plone/contenttypes/interfaces/documento_personale.py:83
 msgid "Autore"
 msgstr ""
 
@@ -116,19 +111,19 @@ msgstr ""
 msgid "Autorizzare"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:81
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:73
 msgid "Avvio impresa"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:82
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:74
 msgid "Avvio nuova attività professionale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:85
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:77
 msgid "Avvio/registrazione filiale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:96
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:86
 msgid "Bancarotta"
 msgstr ""
 
@@ -136,11 +131,11 @@ msgstr ""
 msgid "CAP"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:49
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:44
 msgid "Cambio di residenza/domicilio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:122
+#: design/plone/contenttypes/interfaces/documento.py:109
 msgid "Canale digitale al servizio collegato"
 msgstr ""
 
@@ -148,11 +143,11 @@ msgstr ""
 msgid "Canon 5D IV"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:93
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:83
 msgid "Chiusura filiale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:91
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:82
 msgid "Chiusura impresa e attività professionale"
 msgstr ""
 
@@ -160,15 +155,15 @@ msgstr ""
 msgid "Città"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:123
+#: design/plone/contenttypes/interfaces/persona.py:161
 msgid "Collegamenti organizzazione di I livello"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:152
+#: design/plone/contenttypes/interfaces/persona.py:190
 msgid "Collegamenti organizzazione di II livello"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:45
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:40
 msgid "Compravendita/affitto casa/edifici/terreni, costruzione o ristrutturazione casa/edificio	"
 msgstr ""
 
@@ -188,17 +183,17 @@ msgstr ""
 msgid "Cultura"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:140
-#: design/plone/contenttypes/interfaces/documento_personale.py:133
+#: design/plone/contenttypes/interfaces/documento.py:127
+#: design/plone/contenttypes/interfaces/documento_personale.py:125
 #: design/plone/contenttypes/profiles/default/types/Dataset.xml
 msgid "Dataset"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento_personale.py:137
+#: design/plone/contenttypes/interfaces/documento_personale.py:129
 msgid "Dataset collegato"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:65
+#: design/plone/contenttypes/behaviors/configure.zcml:82
 msgid "Dataset correlati"
 msgstr ""
 
@@ -206,8 +201,12 @@ msgstr ""
 msgid "Delegare"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:63
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:55
 msgid "Denuncia crimini"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:130
+msgid "Descrizione estesa"
 msgstr ""
 
 #: design/plone/contenttypes/configure.zcml:34
@@ -218,7 +217,7 @@ msgstr ""
 msgid "Design Plone: Content-types (uninstall)"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:66
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:58
 msgid "Dichiarazione dei redditi, versamento e riscossione tributi/imposte e contributi"
 msgstr ""
 
@@ -226,7 +225,7 @@ msgstr ""
 msgid "Documenti albo pretorio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:278
+#: design/plone/contenttypes/interfaces/servizio.py:254
 #: design/plone/contenttypes/profiles/default/types/Documento.xml
 msgid "Documento"
 msgstr ""
@@ -245,10 +244,6 @@ msgstr ""
 
 #: design/plone/contenttypes/vocabularies/document_types_vocabulary.py:34
 msgid "Documento funzionamento interno"
-msgstr ""
-
-#: design/plone/contenttypes/interfaces/servizio.py:387
-msgid "Dove trovarci"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/dataset.py:31
@@ -270,11 +265,7 @@ msgstr ""
 msgid "Energia"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:247
-msgid "Evento figlio"
-msgstr ""
-
-#: design/plone/contenttypes/behaviors/evento.py:224
+#: design/plone/contenttypes/behaviors/evento.py:150
 msgid "Evento supportato da"
 msgstr ""
 
@@ -286,7 +277,7 @@ msgstr ""
 msgid "Fanciullo"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:86
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:78
 msgid "Finanziamento impresa"
 msgstr ""
 
@@ -303,7 +294,7 @@ msgstr ""
 msgid "Gestione dei rifiuti"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:87
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:79
 msgid "Gestione personale"
 msgstr ""
 
@@ -333,6 +324,10 @@ msgstr ""
 
 #: design/plone/contenttypes/controlpanels/vocabularies.py:35
 msgid "Indicare le dimensioni delle lead image dei contenuti"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:141
+msgid "Info per la testata"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/lista_azioni_pratica.py:33
@@ -367,7 +362,7 @@ msgstr ""
 msgid "Integrazione sociale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:34
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:29
 msgid "Invalidità"
 msgstr ""
 
@@ -375,7 +370,7 @@ msgstr ""
 msgid "Iscriversi"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:30
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:25
 msgid "Iscrizione scuola/università e/o richiesta borsa di studio"
 msgstr ""
 
@@ -395,19 +390,15 @@ msgstr ""
 msgid "Leggere"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:55
+#: design/plone/contenttypes/behaviors/configure.zcml:63
 msgid "Luoghi correlati"
-msgstr ""
-
-#: design/plone/contenttypes/behaviors/evento.py:128
-msgid "Luogo dell'evento"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:47
 msgid "Matrimonio"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:60
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:52
 msgid "Matrimonio e/o cambio stato civile"
 msgstr ""
 
@@ -431,11 +422,11 @@ msgstr ""
 msgid "Modulistica"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:61
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:53
 msgid "Morte ed eredità"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:58
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:51
 msgid "Nascita di un bambino, richiesta adozioni"
 msgstr ""
 
@@ -443,24 +434,29 @@ msgstr ""
 msgid "Nazione"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:89
+#. Default: "Nome e cognome"
+#: design/plone/contenttypes/restapi/services/types/get.py:106
+msgid "Nome e Cognome"
+msgstr ""
+
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:81
 msgid "Notifiche autorità"
 msgstr ""
 
 #. Default: "Organizzato da (interno)"
-#: design/plone/contenttypes/behaviors/evento.py:172
+#: design/plone/contenttypes/behaviors/evento.py:122
 msgid "Organizzato da_interno"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:177
+#: design/plone/contenttypes/behaviors/evento.py:125
 msgid "Organizzatore"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:45
+#: design/plone/contenttypes/interfaces/persona.py:105
 msgid "Organizzazione di riferimento"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:88
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:80
 msgid "Pagamento tasse, iva e dogane"
 msgstr ""
 
@@ -476,11 +472,11 @@ msgstr ""
 msgid "Paperino"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:99
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:89
 msgid "Partecipazione ad appalti pubblici nazionali e trasfrontalieri"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:39
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:34
 msgid "Pensionamento"
 msgstr ""
 
@@ -488,11 +484,11 @@ msgstr ""
 msgid "Persona"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:109
-msgid "Persona dell'amminnistrazione"
+#: design/plone/contenttypes/behaviors/evento.py:43
+msgid "Persona dell'amministrazione"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:125
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:87
 msgid "Persone della struttura"
 msgstr ""
 
@@ -512,7 +508,7 @@ msgstr ""
 msgid "Popolazione e società"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:73
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:65
 msgid "Possesso, cura, smarrimento animale da compagnia"
 msgstr ""
 
@@ -520,7 +516,7 @@ msgstr ""
 msgid "Pratica"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:62
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:54
 msgid "Prenotazione e disdetta visite/esami"
 msgstr ""
 
@@ -532,23 +528,23 @@ msgstr ""
 msgid "Regioni e città"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:84
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:76
 msgid "Registrazione impresa transfrontalier"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:41
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:36
 msgid "Registrazione/possesso veicolo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:57
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:43
 msgid "Responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:70
+#: design/plone/contenttypes/interfaces/persona.py:130
 msgid "Responsabile di"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:37
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:32
 msgid "Ricerca di lavoro, avvio nuovo lavoro, disoccupazione"
 msgstr ""
 
@@ -560,19 +556,19 @@ msgstr ""
 msgid "Richiedere"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:83
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:75
 msgid "Richiesta licenze/permessi/certificati"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:40
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:35
 msgid "Richiesta o rinnovo patente"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:53
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:47
 msgid "Richiesta passaporto, visto e assistenza viaggi internazionali"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:94
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:84
 msgid "Ristrutturazione impresa"
 msgstr ""
 
@@ -585,15 +581,15 @@ msgstr ""
 msgid "Scienza e tecnologia"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:188
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:108
 msgid "Sede"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:364
+#: design/plone/contenttypes/interfaces/servizio.py:319
 msgid "Servizi collegati"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:75
+#: design/plone/contenttypes/behaviors/configure.zcml:92
 msgid "Servizi correlati"
 msgstr ""
 
@@ -601,8 +597,8 @@ msgstr ""
 msgid "Servizio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:106
-#: design/plone/contenttypes/interfaces/documento_personale.py:104
+#: design/plone/contenttypes/interfaces/documento.py:94
+#: design/plone/contenttypes/interfaces/documento_personale.py:98
 msgid "Servizio collegato"
 msgstr ""
 
@@ -626,16 +622,20 @@ msgstr ""
 msgid "Sport"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:34
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:35
 msgid "Struttura"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:274
+#: design/plone/contenttypes/behaviors/strutture_correlate.py:20
 msgid "Struttura politica coinvolta"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/luogo.py:116
+#: design/plone/contenttypes/behaviors/luogo.py:124
 msgid "Struttura responsabile"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:102
+msgid "Strutture correlate"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:30
@@ -678,11 +678,11 @@ msgstr ""
 msgid "Turismo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:231
+#: design/plone/contenttypes/interfaces/servizio.py:228
 msgid "Ufficio responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:85
+#: design/plone/contenttypes/behaviors/configure.zcml:112
 msgid "Ulteriori campi aiuto testuali"
 msgstr ""
 
@@ -694,11 +694,15 @@ msgstr ""
 msgid "Unita Organizzativa"
 msgstr ""
 
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:35
+msgid "Unità amministrativa responsabile"
+msgstr ""
+
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:38
 msgid "Urbanistica ed edilizia"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:95
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:85
 msgid "Vendita impresa"
 msgstr ""
 
@@ -720,24 +724,39 @@ msgstr ""
 msgid "Vocabolari Design Plone"
 msgstr ""
 
+#. Default: "A chi si rivolge questo servizio e chi può usufruirne."
+#: design/plone/contenttypes/interfaces/servizio.py:57
+msgid "a_chi_si_rivolge_help"
+msgstr ""
+
+#. Default: "A chi si rivolge"
+#: design/plone/contenttypes/interfaces/servizio.py:55
+msgid "a_chi_si_rivolge_label"
+msgstr ""
+
 #. Default: "Seleziona l'ufficio di comunicazione responsabile di questa notizia/comunicato stampa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:39
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:38
 msgid "a_cura_di_help"
 msgstr ""
 
 #. Default: "A cura di"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:38
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:37
 msgid "a_cura_di_label"
 msgstr ""
 
 #. Default: "Seleziona una lista di persone dell'amministrazione citate in questa notizia/comunicato stampa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:51
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:50
 msgid "a_cura_di_persone_help"
 msgstr ""
 
 #. Default: "Persone"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:50
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:49
 msgid "a_cura_di_persone_label"
+msgstr ""
+
+#. Default: "Accedi al servizio"
+#: design/plone/contenttypes/interfaces/servizio.py:388
+msgid "accedi_al_servizio_label"
 msgstr ""
 
 #. Default: "Allegato"
@@ -746,77 +765,67 @@ msgid "allegato"
 msgstr ""
 
 #. Default: "Seleziona la lista dei documenti di supporto collegati a questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:272
+#: design/plone/contenttypes/interfaces/servizio.py:248
 msgid "altri_documenti_help"
 msgstr ""
 
 #. Default: "Area"
-#: design/plone/contenttypes/interfaces/servizio.py:246
+#: design/plone/contenttypes/interfaces/servizio.py:234
 msgid "area"
 msgstr ""
 
-#. Default: "Area di appartenenza"
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:16
-msgid "area_di_appartenenza"
-msgstr ""
-
 #. Default: "Seleziona l'area da cui dipende questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:249
+#: design/plone/contenttypes/interfaces/servizio.py:237
 msgid "area_help"
 msgstr ""
 
 #. Default: "Area responsabile del documento"
-#: design/plone/contenttypes/interfaces/documento.py:58
+#: design/plone/contenttypes/interfaces/documento.py:49
 msgid "area_responsabile"
 msgstr ""
 
 #. Default: "Area responsabile"
-#: design/plone/contenttypes/interfaces/documento_personale.py:79
+#: design/plone/contenttypes/interfaces/documento_personale.py:73
 msgid "area_responsabile_documento_personale"
 msgstr ""
 
 #. Default: "Argomenti utenti"
-#: design/plone/contenttypes/interfaces/documento_personale.py:46
+#: design/plone/contenttypes/interfaces/documento_personale.py:43
 msgid "argomenti_utenti"
 msgstr ""
 
-#. Default: "Assessorati di riferimento"
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:35
-msgid "assessorati_riferimento"
-msgstr ""
-
 #. Default: "Inserire l'assessore di riferimento della struttura, se esiste."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:101
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:73
 msgid "assessore_riferimento_help"
 msgstr ""
 
 #. Default: "Atto nomina"
-#: design/plone/contenttypes/interfaces/persona.py:252
+#: design/plone/contenttypes/interfaces/persona.py:244
 msgid "atto_nomina"
 msgstr ""
 
 #. Default: "Atto di nomina della persona."
-#: design/plone/contenttypes/interfaces/persona.py:254
+#: design/plone/contenttypes/interfaces/persona.py:246
 msgid "atto_nomina_help"
 msgstr ""
 
 #. Default: "Autenticazione"
-#: design/plone/contenttypes/interfaces/servizio.py:139
+#: design/plone/contenttypes/interfaces/servizio.py:125
 msgid "autenticazione"
 msgstr ""
 
 #. Default: "Indicare, se previste, le modalità di autenticazione necessarie per poter accedere al servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:140
+#: design/plone/contenttypes/interfaces/servizio.py:126
 msgid "autenticazione_help"
 msgstr ""
 
 #. Default: "Azioni"
-#: design/plone/contenttypes/interfaces/messaggio.py:30
+#: design/plone/contenttypes/interfaces/messaggio.py:28
 msgid "azioni_pratica"
 msgstr ""
 
 #. Default: "Azioni richieste"
-#: design/plone/contenttypes/interfaces/messaggio.py:24
+#: design/plone/contenttypes/interfaces/messaggio.py:22
 msgid "azioni_richieste"
 msgstr ""
 
@@ -826,151 +835,113 @@ msgid "azioni_utente"
 msgstr ""
 
 #. Default: "Biografia"
-#: design/plone/contenttypes/interfaces/persona.py:198
+#: design/plone/contenttypes/interfaces/persona.py:66
 msgid "biografia"
 msgstr ""
 
 #. Default: "Solo per persona politica: testo descrittivo che riporta la biografia della persona."
-#: design/plone/contenttypes/interfaces/persona.py:199
+#: design/plone/contenttypes/interfaces/persona.py:67
 msgid "biografia_help"
 msgstr ""
 
-#. Default: "Box di aiuto"
-#: design/plone/contenttypes/behaviors/evento.py:290
-#: design/plone/contenttypes/interfaces/documento.py:170
-#: design/plone/contenttypes/interfaces/documento_personale.py:153
-msgid "box_aiuto"
-msgstr ""
-
-#. Default: "Ulteriori informazioni sul Servizio, FAQ, eventuali riferimenti normativi ed eventuali contatti di supporto all'utente."
-#: design/plone/contenttypes/interfaces/servizio.py:352
-msgid "box_aiuto_help"
-msgstr ""
-
 #. Default: "Canale digitale"
-#: design/plone/contenttypes/interfaces/servizio.py:129
+#: design/plone/contenttypes/interfaces/servizio.py:115
 msgid "canale_digitale"
 msgstr ""
 
 #. Default: "Collegamento con l'eventuale canale digitale di attivazione del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:130
+#: design/plone/contenttypes/interfaces/servizio.py:116
 msgid "canale_digitale_help"
 msgstr ""
 
 #. Default: "Canale digitale servizio collegato"
-#: design/plone/contenttypes/interfaces/documento_personale.py:111
+#: design/plone/contenttypes/interfaces/documento_personale.py:104
 msgid "canale_digitale_servizio"
 msgstr ""
 
-#. Default: "Canale fisico"
-#: design/plone/contenttypes/interfaces/servizio.py:149
-msgid "canale_fisico"
-msgstr ""
-
-#. Default: "Indica le sedi dove è possibile usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:150
-msgid "canale_fisico_help"
-msgstr ""
-
-#. Default: "Canale fisico - prenotazione"
-#: design/plone/contenttypes/interfaces/servizio.py:158
-msgid "canale_fisico_prenotazione"
-msgstr ""
-
-#. Default: "Se è possibile prenotare un'appuntamento, indicare il collegamento al servizio di prenotazione appuntamenti del Comune."
-#: design/plone/contenttypes/interfaces/servizio.py:162
-msgid "canale_fisico_prenotazione_help"
-msgstr ""
-
-#. Default: "CAP"
-#: design/plone/contenttypes/behaviors/evento.py:153
-msgid "cap"
-msgstr ""
-
 #. Default: "Casi particolari"
-#: design/plone/contenttypes/interfaces/servizio.py:211
+#: design/plone/contenttypes/interfaces/servizio.py:208
 msgid "casi_particolari"
 msgstr ""
 
 #. Default: "Descrizione degli evetuali casi particolari riferiti alla fruibilità di questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:213
+#: design/plone/contenttypes/interfaces/servizio.py:210
 msgid "casi_particolari_help"
 msgstr ""
 
-#. Default: "Categoria prevalente"
-#: design/plone/contenttypes/behaviors/luogo.py:96
-msgid "categoria_prevalente"
-msgstr ""
-
-#. Default: "Chi può presentare"
-#: design/plone/contenttypes/interfaces/servizio.py:76
-msgid "chi_puo_presentare"
+#. Default: "Casi particolari"
+#: design/plone/contenttypes/interfaces/servizio.py:419
+msgid "casi_particolari_label"
 msgstr ""
 
 #. Default: "Descrizione di chi può presentare domanda per usufruire del servizio e delle diverse casistiche."
-#: design/plone/contenttypes/interfaces/servizio.py:78
+#: design/plone/contenttypes/interfaces/servizio.py:66
 msgid "chi_puo_presentare_help"
 msgstr ""
 
+#. Default: "Chi può presentare"
+#: design/plone/contenttypes/interfaces/servizio.py:64
+msgid "chi_puo_presentare_label"
+msgstr ""
+
 #. Default: "Circoscrizione"
-#: design/plone/contenttypes/behaviors/evento.py:150
-#: design/plone/contenttypes/behaviors/luogo.py:26
+#: design/plone/contenttypes/behaviors/luogo.py:32
 msgid "circoscrizione"
 msgstr ""
 
 #. Default: "Codice dell'ente erogatore (ipa)"
-#: design/plone/contenttypes/interfaces/servizio.py:319
+#: design/plone/contenttypes/interfaces/servizio.py:285
 msgid "codice_ipa"
 msgstr ""
 
 #. Default: "Specificare il nome dell’organizzazione, come indicato nell’Indice della Pubblica Amministrazione (IPA), che esercita uno specifico ruolo sul Servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:321
+#: design/plone/contenttypes/interfaces/servizio.py:287
 msgid "codice_ipa_help"
 msgstr ""
 
 #. Default: "Collegamenti all'organizzazione di I livello"
-#: design/plone/contenttypes/interfaces/persona.py:109
+#: design/plone/contenttypes/interfaces/persona.py:147
 msgid "collegamenti_organizzazione_l1"
 msgstr ""
 
 #. Default: "Seleziona l'organizzazione a cui la persona è collegata. Se si tratta di una persona politica, il collegamento è riferito a una struttura politica. Se si tratta di una persona amministrativa, il collegamento è riferito ad un'area amministrativa."
-#: design/plone/contenttypes/interfaces/persona.py:113
+#: design/plone/contenttypes/interfaces/persona.py:151
 msgid "collegamenti_organizzazione_l1_help"
 msgstr ""
 
 #. Default: "Collegamenti all'organizzazione di II livello"
-#: design/plone/contenttypes/interfaces/persona.py:140
+#: design/plone/contenttypes/interfaces/persona.py:178
 msgid "collegamenti_organizzazione_l2"
 msgstr ""
 
 #. Default: "Seleziona gli assessorati di cui la persona si occupa,  i gruppi politici, commissioni a cui appartiene, oppure gli uffici di cui si occupa o di cui è responsabile."
-#: design/plone/contenttypes/interfaces/persona.py:144
+#: design/plone/contenttypes/interfaces/persona.py:182
 msgid "collegamenti_organizzazione_l2_help"
 msgstr ""
 
 #. Default: "Come si fa"
-#: design/plone/contenttypes/interfaces/servizio.py:96
+#: design/plone/contenttypes/interfaces/servizio.py:84
 msgid "come_si_fa"
 msgstr ""
 
 #. Default: "Descrizione della procedura da seguire per poter usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:98
+#: design/plone/contenttypes/interfaces/servizio.py:86
 msgid "come_si_fa_help"
 msgstr ""
 
 #. Default: "Competenze"
-#: design/plone/contenttypes/interfaces/persona.py:169
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:17
+#: design/plone/contenttypes/interfaces/persona.py:207
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:18
 msgid "competenze"
 msgstr ""
 
 #. Default: "Descrizione del ruolo e dei compiti della persona."
-#: design/plone/contenttypes/interfaces/persona.py:170
+#: design/plone/contenttypes/interfaces/persona.py:208
 msgid "competenze_help"
 msgstr ""
 
 #. Default: "Informazioni di contatto generiche"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:203
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:114
 msgid "contact_info"
 msgstr ""
 
@@ -980,13 +951,20 @@ msgid "contatti"
 msgstr ""
 
 #. Default: "Contatti"
-#: design/plone/contenttypes/behaviors/luogo.py:149
+#: design/plone/contenttypes/behaviors/evento.py:189
+#: design/plone/contenttypes/behaviors/luogo.py:220
+#: design/plone/contenttypes/interfaces/servizio.py:425
 msgid "contatti_label"
 msgstr ""
 
-#. Default: "Contatto: reperibilità"
-#: design/plone/contenttypes/behaviors/evento.py:203
+#. Default: "Reperibilità organizzatore"
+#: design/plone/contenttypes/behaviors/evento.py:112
 msgid "contatto_reperibilita"
+msgstr ""
+
+#. Default: "Indicare gli orari in cui l'organizzatore è telefonicamente reperibile."
+#: design/plone/contenttypes/behaviors/evento.py:114
+msgid "contatto_reperibilita_help"
 msgstr ""
 
 #. Default: "Contenuto"
@@ -994,101 +972,116 @@ msgstr ""
 msgid "contenuto"
 msgstr ""
 
-#. Default: "Copertura geografica"
-#: design/plone/contenttypes/interfaces/servizio.py:86
-msgid "copertura_geografica"
-msgstr ""
-
 #. Default: "Indicare se il servizio si riferisce ad una particolare area geografica o all'intero territorio di riferimento."
-#: design/plone/contenttypes/interfaces/servizio.py:88
+#: design/plone/contenttypes/interfaces/servizio.py:76
 msgid "copertura_geografica_help"
 msgstr ""
 
-#. Default: "Correlati"
-#: design/plone/contenttypes/behaviors/argomenti.py:38
+#. Default: "Copertura geografica"
+#: design/plone/contenttypes/interfaces/servizio.py:74
+msgid "copertura_geografica_label"
+msgstr ""
+
+#. Default: "Contenuti collegati"
+#: design/plone/contenttypes/behaviors/argomenti.py:44
 #: design/plone/contenttypes/behaviors/dataset_correlati.py:40
-#: design/plone/contenttypes/behaviors/luoghi_correlati.py:39
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:38
 msgid "correlati_label"
 msgstr ""
 
 #. Default: "Cosa serve"
-#: design/plone/contenttypes/interfaces/servizio.py:183
+#: design/plone/contenttypes/interfaces/servizio.py:181
 msgid "cosa_serve"
 msgstr ""
 
 #. Default: "Descrizione delle istruzioni per usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:185
+#: design/plone/contenttypes/interfaces/servizio.py:183
 msgid "cosa_serve_help"
 msgstr ""
 
+#. Default: "Cosa serve"
+#: design/plone/contenttypes/interfaces/servizio.py:402
+msgid "cosa_serve_label"
+msgstr ""
+
 #. Default: "Cosa si ottiene"
-#: design/plone/contenttypes/interfaces/servizio.py:106
+#: design/plone/contenttypes/interfaces/servizio.py:94
 msgid "cosa_si_ottiene"
 msgstr ""
 
 #. Default: "Indicare cosa si può ottenere dal servizio, ad esempio 'carta di identità elettronica', 'certificato di residenza'."
-#: design/plone/contenttypes/interfaces/servizio.py:107
+#: design/plone/contenttypes/interfaces/servizio.py:95
 msgid "cosa_si_ottiene_help"
 msgstr ""
 
 #. Default: "Costi"
-#: design/plone/contenttypes/interfaces/servizio.py:192
+#: design/plone/contenttypes/interfaces/servizio.py:190
 msgid "costi"
 msgstr ""
 
+#. Default: "Costi e vincoli"
+#: design/plone/contenttypes/interfaces/servizio.py:407
+msgid "costi_e_vincoli_label"
+msgstr ""
+
 #. Default: "Descrizione delle condizioni e dei termini economici per completare la procedura di richiesta del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:194
+#: design/plone/contenttypes/interfaces/servizio.py:192
 msgid "costi_help"
 msgstr ""
 
+#. Default: "Costi"
+#: design/plone/contenttypes/behaviors/evento.py:186
+msgid "costi_label"
+msgstr ""
+
 #. Default: "Curriculum vitae"
-#: design/plone/contenttypes/interfaces/persona.py:232
+#: design/plone/contenttypes/interfaces/persona.py:224
 msgid "curriculum_vitae"
 msgstr ""
 
 #. Default: "Curriculum vitae della persona."
-#: design/plone/contenttypes/interfaces/persona.py:234
+#: design/plone/contenttypes/interfaces/persona.py:226
 msgid "curriculum_vitae_help"
 msgstr ""
 
 #. Default: "Data conclusione incarico"
-#: design/plone/contenttypes/interfaces/persona.py:98
+#: design/plone/contenttypes/interfaces/persona.py:57
 msgid "data_conclusione_incarico"
 msgstr ""
 
 #. Default: "Data di conclusione dell'incarico."
-#: design/plone/contenttypes/interfaces/persona.py:101
+#: design/plone/contenttypes/interfaces/persona.py:58
 msgid "data_conclusione_incarico_help"
 msgstr ""
 
 #. Default: "Data e fasi intermedie"
-#: design/plone/contenttypes/interfaces/documento_personale.py:123
+#: design/plone/contenttypes/interfaces/documento_personale.py:115
 msgid "data_e_fasi_intermedie"
 msgstr ""
 
 #. Default: "Data di scadenza"
-#: design/plone/contenttypes/interfaces/documento.py:133
+#: design/plone/contenttypes/interfaces/documento.py:120
 msgid "data_fine"
 msgstr ""
 
 #. Default: "Data di inizio"
-#: design/plone/contenttypes/interfaces/documento.py:127
-#: design/plone/contenttypes/interfaces/documento_personale.py:119
+#: design/plone/contenttypes/interfaces/documento.py:114
+#: design/plone/contenttypes/interfaces/documento_personale.py:111
 msgid "data_inizio"
 msgstr ""
 
 #. Default: "Data insediamento"
-#: design/plone/contenttypes/interfaces/persona.py:88
+#: design/plone/contenttypes/interfaces/persona.py:47
 msgid "data_insediamento"
 msgstr ""
 
 #. Default: "Solo per persona politica: specificare la data di insediamento."
-#: design/plone/contenttypes/interfaces/persona.py:89
+#: design/plone/contenttypes/interfaces/persona.py:48
 msgid "data_insediamento_help"
 msgstr ""
 
 #. Default: "Data del messaggio"
-#: design/plone/contenttypes/interfaces/messaggio.py:14
+#: design/plone/contenttypes/interfaces/messaggio.py:13
 msgid "data_messaggio"
 msgstr ""
 
@@ -1098,13 +1091,13 @@ msgid "data_pagamento"
 msgstr ""
 
 #. Default: "Data del protocollo"
-#: design/plone/contenttypes/interfaces/documento.py:165
+#: design/plone/contenttypes/interfaces/documento.py:149
 #: design/plone/contenttypes/interfaces/documento_personale.py:20
 msgid "data_protocollo"
 msgstr ""
 
 #. Default: "Data di scadenza della procedura"
-#: design/plone/contenttypes/interfaces/messaggio.py:45
+#: design/plone/contenttypes/interfaces/messaggio.py:42
 msgid "data_scadenza_procedura"
 msgstr ""
 
@@ -1123,46 +1116,44 @@ msgstr ""
 msgid "dataset_correlati_label"
 msgstr ""
 
-#. Default: "Date significative"
-#: design/plone/contenttypes/behaviors/evento.py:156
-msgid "date_significative"
+#. Default: "Date dell'evento"
+#: design/plone/contenttypes/behaviors/evento.py:204
+#: design/plone/contenttypes/schema_overrides.py:35
+msgid "date_evento_label"
 msgstr ""
 
 #. Default: "Deleghe"
-#: design/plone/contenttypes/interfaces/persona.py:178
+#: design/plone/contenttypes/interfaces/persona.py:216
 msgid "deleghe"
 msgstr ""
 
 #. Default: "Elenco delle deleghe a capo della persona."
-#: design/plone/contenttypes/interfaces/persona.py:179
+#: design/plone/contenttypes/interfaces/persona.py:217
 msgid "deleghe_help"
 msgstr ""
 
-#. Default: "Descrizione breve"
-#: design/plone/contenttypes/behaviors/luogo.py:30
-msgid "descrizione_breve"
+#. Default: "Descrizione completa"
+#: design/plone/contenttypes/behaviors/luogo.py:42
+msgid "descrizione_completa"
 msgstr ""
 
 #. Default: "Descrizione destinatari"
-#: design/plone/contenttypes/behaviors/evento.py:99
-#: design/plone/contenttypes/interfaces/servizio.py:64
+#: design/plone/contenttypes/behaviors/evento.py:31
 msgid "descrizione_destinatari"
 msgstr ""
 
-#. Default: "Descrizione dei principali interlocutori del servizio: a chi si rivolge e chi può usufruirne."
-#: design/plone/contenttypes/interfaces/servizio.py:68
+#. Default: "Descrizione dei principali interlocutori dell'evento."
+#: design/plone/contenttypes/behaviors/evento.py:33
 msgid "descrizione_destinatari_help"
 msgstr ""
 
 #. Default: "Descrizione estesa"
-#: design/plone/contenttypes/interfaces/documento.py:31
-#: design/plone/contenttypes/interfaces/documento_personale.py:58
-#: design/plone/contenttypes/interfaces/servizio.py:55
+#: design/plone/contenttypes/behaviors/descrizione_estesa.py:17
 msgid "descrizione_estesa"
 msgstr ""
 
-#. Default: "Descrizione dettagliata e completa del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:57
+#. Default: "Descrizione dettagliata e completa."
+#: design/plone/contenttypes/behaviors/descrizione_estesa.py:19
 msgid "descrizione_estesa_help"
 msgstr ""
 
@@ -1172,22 +1163,47 @@ msgid "distribuzione"
 msgstr ""
 
 #. Default: "Documenti allegati"
-#: design/plone/contenttypes/interfaces/messaggio.py:61
+#: design/plone/contenttypes/interfaces/messaggio.py:57
 msgid "documenti_allegati"
 msgstr ""
 
+#. Default: "Documenti"
+#: design/plone/contenttypes/interfaces/servizio.py:430
+msgid "documenti_label"
+msgstr ""
+
+#. Default: "Dove"
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:65
+msgid "dove_label"
+msgstr ""
+
+#. Default: "Dove rivolgersi: informazioni aggiuntive"
+#: design/plone/contenttypes/interfaces/servizio.py:147
+msgid "dove_rivolgersi_extra"
+msgstr ""
+
+#. Default: "Indicare eventuali informazioni aggiuntive riguardo al dove rivolgersi per questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:151
+msgid "dove_rivolgersi_extra_help"
+msgstr ""
+
+#. Default: "Seleziona una lista delle sedi e dei luoghi in cui è presente questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:139
+msgid "dove_rivolgersi_help"
+msgstr ""
+
 #. Default: "Elementi di interesse"
-#: design/plone/contenttypes/behaviors/luogo.py:38
+#: design/plone/contenttypes/behaviors/luogo.py:63
 msgid "elementi_di_interesse"
 msgstr ""
 
 #. Default: "Indirizzo email"
-#: design/plone/contenttypes/interfaces/persona.py:216
+#: design/plone/contenttypes/interfaces/persona.py:82
 msgid "email"
 msgstr ""
 
 #. Default: "Contatto mail della persona."
-#: design/plone/contenttypes/interfaces/persona.py:217
+#: design/plone/contenttypes/interfaces/persona.py:83
 msgid "email_help"
 msgstr ""
 
@@ -1196,23 +1212,8 @@ msgstr ""
 msgid "esito"
 msgstr ""
 
-#. Default: "Evento genitore"
-#: design/plone/contenttypes/behaviors/evento.py:68
-msgid "evento_genitore"
-msgstr ""
-
-#. Default: "Fasi e scadenze"
-#: design/plone/contenttypes/interfaces/servizio.py:172
-msgid "fasi_scadenze"
-msgstr ""
-
-#. Default: "Prevedere una data di scadenza del servizio. Se il servizio è diviso in fasi, descriverne modalità e tempistiche."
-#: design/plone/contenttypes/interfaces/servizio.py:174
-msgid "fasi_scadenze_help"
-msgstr ""
-
 #. Default: "Foto da mostrare della persona; la dimensione suggerita è 180x100 px"
-#: design/plone/contenttypes/interfaces/persona.py:20
+#: design/plone/contenttypes/interfaces/persona.py:21
 msgid "foto_persona_help"
 msgstr ""
 
@@ -1226,8 +1227,78 @@ msgstr ""
 msgid "geolocation_field_validator_label"
 msgstr ""
 
+#. Default: "Indicare l'eventuale circoscrizione in cui si trova questo luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:33
+msgid "help_circoscrizione"
+msgstr ""
+
+#. Default: "Indicare una descrizione completa, inserendo tutte le informazioni rilevanti relative al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:43
+msgid "help_descrizione_completa"
+msgstr ""
+
+#. Default: "Indicare eventuali elementi di interesse relativi al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:64
+msgid "help_elementi_di_interesse"
+msgstr ""
+
+#. Default: "Indicare tutte le informazioni relative alla modalità di accesso al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:73
+msgid "help_modalita_accesso"
+msgstr ""
+
+#. Default: "Indicare, se esiste, un nome alternativo per il luogo; questo sarà mostrato tra parentesi affiancato al titolo della scheda"
+#: design/plone/contenttypes/behaviors/luogo.py:53
+msgid "help_nome_alternativo"
+msgstr ""
+
+#. Default: "Indicare eventuali orari di accesso al pubblico"
+#: design/plone/contenttypes/behaviors/luogo.py:105
+msgid "help_orario_pubblico"
+msgstr ""
+
+#. Default: "Indicare l'eventuale quartiere in cui si trova questo luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:24
+msgid "help_quartiere"
+msgstr ""
+
+#. Default: "Indicare un indirizzo mail per poter contattare i referenti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:95
+msgid "help_riferimento_mail_luogo"
+msgstr ""
+
+#. Default: "Indicare un indirizzo mail per poter contattare i referenti della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:170
+msgid "help_riferimento_mail_struttura"
+msgstr ""
+
+#. Default: "Indicare un riferimento telefonico per poter contattare i referenti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:85
+msgid "help_riferimento_telefonico_luogo"
+msgstr ""
+
+#. Default: "Indicare il riferimento telefonico per poter contattare i referenti della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:157
+msgid "help_riferimento_telefonico_struttura"
+msgstr ""
+
+#. Default: "Indicare un indirizzo web utile per ottenere i contatti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:180
+msgid "help_riferimento_web"
+msgstr ""
+
+#. Default: "Icona"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:17
+msgid "icona"
+msgstr ""
+
+#. Default: "Puoi selezionare un’icona fra quelle proposte nel menu a tendina oppure puoi scrivere/incollare nel campo di testo il nome di un’icona di fontawsome 5"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:18
+msgid "icona_help"
+msgstr ""
+
 #. Default: "Identificativo"
-#: design/plone/contenttypes/interfaces/servizio.py:341
+#: design/plone/contenttypes/interfaces/servizio.py:307
 msgid "identificativo"
 msgstr ""
 
@@ -1237,24 +1308,14 @@ msgid "identificativo_documento"
 msgstr ""
 
 #. Default: "Eventuale codice identificativo del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:343
+#: design/plone/contenttypes/interfaces/servizio.py:309
 msgid "identificativo_help"
 msgstr ""
 
-#. Default: "Identificativo"
-#: design/plone/contenttypes/behaviors/luogo.py:106
-msgid "identificativo_mibac"
-msgstr ""
-
-#. Default: "Identifier"
-#: design/plone/contenttypes/behaviors/evento.py:46
-msgid "identifier"
-msgstr ""
-
 #. Default: "Immagine"
-#: design/plone/contenttypes/behaviors/evento.py:54
 #: design/plone/contenttypes/interfaces/documento.py:23
 #: design/plone/contenttypes/interfaces/documento_personale.py:24
+#: design/plone/contenttypes/interfaces/persona.py:19
 msgid "immagine"
 msgstr ""
 
@@ -1263,33 +1324,45 @@ msgstr ""
 msgid "importo_pagato"
 msgstr ""
 
-#. Default: "Indirizzo"
-#: design/plone/contenttypes/behaviors/evento.py:142
-msgid "indirizzo"
+#. Default: "Inserisci eventuale testo informativo che verrà mostrato in testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:23
+msgid "info_testata_help"
+msgstr ""
+
+#. Default: "Informazioni aggiuntive per la testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:18
+msgid "info_testata_label"
 msgstr ""
 
 #. Default: "Ulteriori informazioni"
-#: design/plone/contenttypes/interfaces/documento_personale.py:143
+#: design/plone/contenttypes/interfaces/documento_personale.py:134
 msgid "informazioni"
 msgstr ""
 
 #. Default: "Informazioni di contatto"
-#: design/plone/contenttypes/interfaces/persona.py:221
+#: design/plone/contenttypes/interfaces/persona.py:88
 msgid "informazioni_di_contatto"
 msgstr ""
 
 #. Default: "Altre informazioni di contatto."
-#: design/plone/contenttypes/interfaces/persona.py:224
+#: design/plone/contenttypes/interfaces/persona.py:89
 msgid "informazioni_di_contatto_help"
 msgstr ""
 
-#. Default: "Introduzione"
-#: design/plone/contenttypes/behaviors/evento.py:92
-msgid "introduzione"
+#. Default: "Ulteriori informazioni"
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:29
+#: design/plone/contenttypes/behaviors/evento.py:199
+#: design/plone/contenttypes/schema_overrides.py:54
+msgid "informazioni_label"
+msgstr ""
+
+#. Default: "Categorization"
+#: design/plone/contenttypes/behaviors/argomenti.py:65
+msgid "label_schema_categorization"
 msgstr ""
 
 #. Default: "Selezionare la lista di strutture e/o uffici collegati a questa unità organizzativa."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:28
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:29
 msgid "legami_con_altre_strutture_help"
 msgstr ""
 
@@ -1299,30 +1372,40 @@ msgid "licenza"
 msgstr ""
 
 #. Default: "Licenza di distribuzione"
-#: design/plone/contenttypes/interfaces/documento.py:97
-#: design/plone/contenttypes/interfaces/documento_personale.py:95
+#: design/plone/contenttypes/interfaces/documento.py:85
+#: design/plone/contenttypes/interfaces/documento_personale.py:89
 msgid "licenza_distribuzione"
 msgstr ""
 
 #. Default: "Parte del life event"
-#: design/plone/contenttypes/interfaces/documento.py:177
-#: design/plone/contenttypes/interfaces/servizio.py:307
+#: design/plone/contenttypes/interfaces/documento.py:156
+#: design/plone/contenttypes/interfaces/servizio.py:273
 msgid "life_event"
 msgstr ""
 
 #. Default: "Collegamento tra il servizio e un evento della vita di una persona o di un'impresa. Ad esempio: il servizio 'Anagrafe' è collegato alla nascita di un bambino"
-#: design/plone/contenttypes/interfaces/servizio.py:308
+#: design/plone/contenttypes/interfaces/servizio.py:274
 msgid "life_event_help"
 msgstr ""
 
 #. Default: "Link a siti esterni"
-#: design/plone/contenttypes/interfaces/servizio.py:294
+#: design/plone/contenttypes/interfaces/servizio.py:260
 msgid "link_siti_esterni"
 msgstr ""
 
 #. Default: "Eventuali collegamenti a pagine web, siti, servizi esterni all'ambito Comunale utili all'erogazione del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:296
+#: design/plone/contenttypes/interfaces/servizio.py:262
 msgid "link_siti_esterni_help"
+msgstr ""
+
+#. Default: "Link utili"
+#: design/plone/contenttypes/interfaces/servizio.py:435
+msgid "link_utili_label"
+msgstr ""
+
+#. Default: "Luoghi dell'evento"
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:56
+msgid "luoghi_correlati_evento_label"
 msgstr ""
 
 #. Default: "Seleziona una lista di luoghi citati."
@@ -1335,13 +1418,8 @@ msgstr ""
 msgid "luoghi_correlati_label"
 msgstr ""
 
-#. Default: "Luogo dell'evento"
-#: design/plone/contenttypes/behaviors/evento.py:125
-msgid "luogo_evento"
-msgstr ""
-
 #. Default: "Modalita' di accesso"
-#: design/plone/contenttypes/behaviors/luogo.py:43
+#: design/plone/contenttypes/behaviors/luogo.py:72
 msgid "modalita_accesso"
 msgstr ""
 
@@ -1350,33 +1428,43 @@ msgstr ""
 msgid "modalita_pagamento"
 msgstr ""
 
-#. Default: "Motivo dello stato del servizio nel caso non sia attivo"
-#: design/plone/contenttypes/interfaces/servizio.py:33
-msgid "motivo_stato_servizio"
+#. Default: "Seleziona se mostrare o meno la navigazione laterale nella testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:43
+msgid "mostra_navigazione_help"
+msgstr ""
+
+#. Default: "Mostra la navigazione"
+#: design/plone/contenttypes/behaviors/info_testata.py:40
+msgid "mostra_navigazione_label"
 msgstr ""
 
 #. Default: "Descrizione del motivo per cui il servizio non è attivo."
-#: design/plone/contenttypes/interfaces/servizio.py:38
+#: design/plone/contenttypes/interfaces/servizio.py:48
 msgid "motivo_stato_servizio_help"
 msgstr ""
 
+#. Default: "Motivo dello stato del servizio nel caso non sia attivo"
+#: design/plone/contenttypes/interfaces/servizio.py:43
+msgid "motivo_stato_servizio_label"
+msgstr ""
+
 #. Default: "Nome alternativo"
-#: design/plone/contenttypes/behaviors/luogo.py:34
+#: design/plone/contenttypes/behaviors/luogo.py:52
 msgid "nome_alternativo"
 msgstr ""
 
 #. Default: "Seleziona una lista di notizie correlate a questa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:63
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:62
 msgid "notizie_correlate_help"
 msgstr ""
 
 #. Default: "Notizie correlate"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:62
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:61
 msgid "notizie_correlate_label"
 msgstr ""
 
 #. Default: "Numero progressivo del comunicato stampa"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:30
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:29
 msgid "numero_progressivo_cs_label"
 msgstr ""
 
@@ -1387,48 +1475,78 @@ msgid "numero_protocollo"
 msgstr ""
 
 #. Default: "Oggetto"
-#: design/plone/contenttypes/interfaces/documento_personale.py:52
+#: design/plone/contenttypes/interfaces/documento_personale.py:49
 msgid "oggetto"
 msgstr ""
 
-#. Default: "Orari"
-#: design/plone/contenttypes/behaviors/evento.py:160
+#. Default: "Informazioni sugli orari"
+#: design/plone/contenttypes/behaviors/evento.py:82
 msgid "orari"
 msgstr ""
 
+#. Default: "Informazioni sugli orari di svolgimento dell'evento."
+#: design/plone/contenttypes/behaviors/evento.py:84
+msgid "orari_help"
+msgstr ""
+
 #. Default: "Orario per il pubblico"
-#: design/plone/contenttypes/behaviors/luogo.py:59
+#: design/plone/contenttypes/behaviors/luogo.py:104
 msgid "orario_pubblico"
 msgstr ""
 
 #. Default: "Organizzato da"
-#: design/plone/contenttypes/behaviors/evento.py:167
+#: design/plone/contenttypes/behaviors/evento.py:102
 msgid "organizzato_da_esterno"
 msgstr ""
 
+#. Default: "Se l'evento non è organizzato direttamente dal comune, indicare l'organizzatore."
+#: design/plone/contenttypes/behaviors/evento.py:104
+msgid "organizzato_da_esterno_help"
+msgstr ""
+
+#. Default: "Se l'evento è organizzato direttamente dal comune, indicare l'ufficio/ente organizzatore."
+#: design/plone/contenttypes/behaviors/evento.py:128
+msgid "organizzato_da_interno_help"
+msgstr ""
+
 #. Default: "Organizzazione di riferimento"
-#: design/plone/contenttypes/interfaces/persona.py:35
+#: design/plone/contenttypes/interfaces/persona.py:96
 msgid "organizzazione_riferimento"
 msgstr ""
 
 #. Default: "Seleziona una lista di organizzazioni a cui la persona appartiene."
-#: design/plone/contenttypes/interfaces/persona.py:39
+#: design/plone/contenttypes/interfaces/persona.py:99
 msgid "organizzazione_riferimento_help"
 msgstr ""
 
+#. Default: "Partecipanti"
+#: design/plone/contenttypes/behaviors/evento.py:183
+msgid "partecipanti_label"
+msgstr ""
+
 #. Default: "Patrocinato da"
-#: design/plone/contenttypes/behaviors/evento.py:263
+#: design/plone/contenttypes/behaviors/evento.py:172
 msgid "patrocinato_da"
 msgstr ""
 
+#. Default: "Indicare l'ente che supporta l'evento, se presente."
+#: design/plone/contenttypes/behaviors/evento.py:174
+msgid "patrocinato_da_help"
+msgstr ""
+
+#. Default: "Elenco delle persone dell'amministrazione che parteciperanno all'evento."
+#: design/plone/contenttypes/behaviors/evento.py:46
+msgid "persone_amministrazione_help"
+msgstr ""
+
 #. Default: "Seleziona la lista delle persone che compongono la struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:128
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:90
 msgid "persone_struttura_help"
 msgstr ""
 
 #. Default: "Pratica associata"
 #: design/plone/contenttypes/interfaces/documento_personale.py:28
-#: design/plone/contenttypes/interfaces/messaggio.py:37
+#: design/plone/contenttypes/interfaces/messaggio.py:35
 msgid "pratica_associata"
 msgstr ""
 
@@ -1437,106 +1555,120 @@ msgstr ""
 msgid "pratica_associata_ricevuta"
 msgstr ""
 
+#. Default: "Prenota un appuntamento"
+#: design/plone/contenttypes/interfaces/servizio.py:160
+msgid "prenota_appuntamento"
+msgstr ""
+
+#. Default: "Se è possibile prenotare un'appuntamento, indicare le informazioni necessarie e il collegamento al servizio di prenotazione appuntamenti del Comune."
+#: design/plone/contenttypes/interfaces/servizio.py:161
+msgid "prenota_appuntamento_help"
+msgstr ""
+
 #. Default: "Prezzo"
-#: design/plone/contenttypes/behaviors/evento.py:164
+#: design/plone/contenttypes/behaviors/evento.py:92
 msgid "prezzo"
 msgstr ""
 
+#. Default: "Indicare il prezzo dell'evento, se presente, specificando se esistono formati diversi."
+#: design/plone/contenttypes/behaviors/evento.py:94
+msgid "prezzo_help"
+msgstr ""
+
 #. Default: "Procedure collegate all'esito"
-#: design/plone/contenttypes/interfaces/servizio.py:116
+#: design/plone/contenttypes/interfaces/servizio.py:104
 msgid "procedure_collegate"
 msgstr ""
 
 #. Default: "Indicare cosa deve fare l'utente del servizio per conoscere l'esito della procedura, e dove eventualmente poter ritirare l'esito."
-#: design/plone/contenttypes/interfaces/servizio.py:120
+#: design/plone/contenttypes/interfaces/servizio.py:106
 msgid "procedure_collegate_help"
 msgstr ""
 
 #. Default: "Protocollo"
-#: design/plone/contenttypes/interfaces/documento.py:161
+#: design/plone/contenttypes/interfaces/documento.py:145
 #: design/plone/contenttypes/interfaces/documento_personale.py:16
 msgid "protocollo"
 msgstr ""
 
 #. Default: "Quartiere"
-#: design/plone/contenttypes/behaviors/evento.py:146
-#: design/plone/contenttypes/behaviors/luogo.py:22
+#: design/plone/contenttypes/behaviors/luogo.py:23
 msgid "quartiere"
 msgstr ""
 
 #. Default: "Responsabile di"
-#: design/plone/contenttypes/interfaces/persona.py:63
+#: design/plone/contenttypes/interfaces/persona.py:123
 msgid "responsabile_di"
 msgstr ""
 
 #. Default: "Seleziona una lista di organizzazioni di cui la persona è responsabile."
-#: design/plone/contenttypes/interfaces/persona.py:64
+#: design/plone/contenttypes/interfaces/persona.py:124
 msgid "responsabile_di_help"
 msgstr ""
 
 #. Default: "Selezionare il/i responsabile/i della struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:60
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:45
 msgid "responsabile_help"
 msgstr ""
 
+#. Default: "Seleziona se mostrare o meno il campo di ricerca in testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:33
+msgid "ricerca_in_testata_help"
+msgstr ""
+
+#. Default: "Ricerca in testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:30
+msgid "ricerca_in_testata_label"
+msgstr ""
+
 #. Default: "Riferimenti normativi"
-#: design/plone/contenttypes/interfaces/documento.py:156
-#: design/plone/contenttypes/interfaces/documento_personale.py:148
+#: design/plone/contenttypes/interfaces/documento.py:140
+#: design/plone/contenttypes/interfaces/documento_personale.py:138
 msgid "riferimenti_normativi"
 msgstr ""
 
 #. Default: "Riferimento mail luogo"
-#: design/plone/contenttypes/behaviors/luogo.py:54
+#: design/plone/contenttypes/behaviors/luogo.py:94
 msgid "riferimento_mail_luogo"
 msgstr ""
 
-#. Default: "Riferimento mail struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:81
+#. Default: "Riferimento mail della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:166
 msgid "riferimento_mail_struttura"
 msgstr ""
 
-#. Default: "Riferimento pec"
-#: design/plone/contenttypes/behaviors/luogo.py:124
-msgid "riferimento_pec"
-msgstr ""
-
 #. Default: "Riferimento telefonico luogo"
-#: design/plone/contenttypes/behaviors/luogo.py:47
+#: design/plone/contenttypes/behaviors/luogo.py:82
 msgid "riferimento_telefonico_luogo"
 msgstr ""
 
-#. Default: "Riferimento telefonico struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:73
+#. Default: "Riferimento telefonico della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:153
 msgid "riferimento_telefonico_struttura"
 msgstr ""
 
 #. Default: "Riferimento sito web"
-#: design/plone/contenttypes/behaviors/luogo.py:89
+#: design/plone/contenttypes/behaviors/luogo.py:179
 msgid "riferimento_web"
 msgstr ""
 
 #. Default: "Ruolo"
-#: design/plone/contenttypes/interfaces/persona.py:26
+#: design/plone/contenttypes/interfaces/persona.py:39
 msgid "ruolo"
 msgstr ""
 
 #. Default: "Descrizione testuale del ruolo di questa persona."
-#: design/plone/contenttypes/interfaces/persona.py:27
+#: design/plone/contenttypes/interfaces/persona.py:40
 msgid "ruolo_help"
 msgstr ""
 
-#. Default: "Seleziona la lista delle sedi e dei luoghi collegati a questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:391
-msgid "sedi_e_luoghi_help"
-msgstr ""
-
 #. Default: "Seleziona una lista delle sedi di questa struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:183
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:104
 msgid "sedi_help"
 msgstr ""
 
 #. Default: "Seleziona la lista dei servizi collegati a questo."
-#: design/plone/contenttypes/interfaces/servizio.py:368
+#: design/plone/contenttypes/interfaces/servizio.py:322
 msgid "servizi_collegati_help"
 msgstr ""
 
@@ -1551,7 +1683,7 @@ msgid "servizi_correlati_label"
 msgstr ""
 
 #. Default: "Servizio che genera il documento"
-#: design/plone/contenttypes/interfaces/documento_personale.py:33
+#: design/plone/contenttypes/interfaces/documento_personale.py:32
 msgid "servizio_origine"
 msgstr ""
 
@@ -1566,23 +1698,23 @@ msgid "servizio_origine_ricevuta"
 msgstr ""
 
 #. Default: "Settore merceologico"
-#: design/plone/contenttypes/interfaces/servizio.py:331
+#: design/plone/contenttypes/interfaces/servizio.py:297
 msgid "settore_merceologico"
 msgstr ""
 
 #. Default: "Classificazione del servizio basata su catalogo dei servizi (Classificazione NACE)."
-#: design/plone/contenttypes/interfaces/servizio.py:333
+#: design/plone/contenttypes/interfaces/servizio.py:299
 msgid "settore_merceologico_help"
 msgstr ""
 
-#. Default: "Sottotitolo"
-#: design/plone/contenttypes/interfaces/servizio.py:45
-msgid "sottotitolo"
+#. Default: "Indica un eventuale sottotitolo/titolo alternativo per questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:22
+msgid "sottotitolo_help"
 msgstr ""
 
-#. Default: "Sponsor"
-#: design/plone/contenttypes/behaviors/evento.py:267
-msgid "sponsor"
+#. Default: "Sottotitolo"
+#: design/plone/contenttypes/interfaces/servizio.py:21
+msgid "sottotitolo_label"
 msgstr ""
 
 #. Default: "Stampa ricevuta"
@@ -1595,58 +1727,68 @@ msgstr ""
 msgid "stato_pratica"
 msgstr ""
 
-#. Default: "Servizio non attivo"
-#: design/plone/contenttypes/interfaces/servizio.py:24
-msgid "stato_servizio"
-msgstr ""
-
 #. Default: "Indica se il servizio è effettivamente fruibile."
-#: design/plone/contenttypes/interfaces/servizio.py:26
+#: design/plone/contenttypes/interfaces/servizio.py:36
 msgid "stato_servizio_help"
 msgstr ""
 
+#. Default: "Servizio non attivo"
+#: design/plone/contenttypes/interfaces/servizio.py:34
+msgid "stato_servizio_label"
+msgstr ""
+
 #. Default: "Struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:63
+#: design/plone/contenttypes/behaviors/luogo.py:143
 msgid "struttura_responsabile"
 msgstr ""
 
+#. Default: "Struttura responsabile del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:113
+msgid "struttura_responsabile_correlati"
+msgstr ""
+
+#. Default: "Indicare la struttura responsabile del luogo qualora sia fra unità organizzative del comune inserite nel sito; altrimenti compilare i campi testuali relativi alla struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:117
+msgid "struttura_responsabile_correlati_help"
+msgstr ""
+
 #. Default: "Nome/link al sito web della struttura che gestisce il luogo, se questa non è comunale."
-#: design/plone/contenttypes/behaviors/luogo.py:65
+#: design/plone/contenttypes/behaviors/luogo.py:145
 msgid "struttura_responsabile_help"
 msgstr ""
 
-#. Default: "Indica un eventuale sottotitolo/titolo alternativo per questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:46
-msgid "subtitle_help"
+#. Default: "Seleziona la lista delle strutture politiche coinvolte."
+#: design/plone/contenttypes/behaviors/strutture_correlate.py:25
+msgid "strutture_politiche_help"
 msgstr ""
 
 #. Default: "Evento supportato da"
-#: design/plone/contenttypes/behaviors/evento.py:221
+#: design/plone/contenttypes/behaviors/evento.py:146
 msgid "supportato_da"
 msgstr ""
 
-#. Default: "Tassonomia argomenti"
-#: design/plone/contenttypes/behaviors/evento.py:58
-msgid "tassonomia_argomenti"
+#. Default: "Se l'evento è organizzato direttamente dal comune, indicare l'ufficio/ente che supporta l'evento."
+#: design/plone/contenttypes/behaviors/evento.py:153
+msgid "supportato_da_help"
 msgstr ""
 
 #. Default: "Seleziona una lista di argomenti d'interesse per questo contenuto."
-#: design/plone/contenttypes/behaviors/argomenti.py:20
+#: design/plone/contenttypes/behaviors/argomenti.py:21
 msgid "tassonomia_argomenti_help"
 msgstr ""
 
 #. Default: "Tassonomia argomenti"
-#: design/plone/contenttypes/behaviors/argomenti.py:19
+#: design/plone/contenttypes/behaviors/argomenti.py:20
 msgid "tassonomia_argomenti_label"
 msgstr ""
 
 #. Default: "Numero di telefono"
-#: design/plone/contenttypes/interfaces/persona.py:208
+#: design/plone/contenttypes/interfaces/persona.py:76
 msgid "telefono"
 msgstr ""
 
 #. Default: "Contatto telefonico della persona."
-#: design/plone/contenttypes/interfaces/persona.py:209
+#: design/plone/contenttypes/interfaces/persona.py:77
 msgid "telefono_help"
 msgstr ""
 
@@ -1655,8 +1797,28 @@ msgstr ""
 msgid "temi"
 msgstr ""
 
+#. Default: "Tempi e scadenze"
+#: design/plone/contenttypes/interfaces/servizio.py:171
+msgid "tempi_e_scadenze"
+msgstr ""
+
+#. Default: "Descrivere le informazioni dettagliate riguardo eventuali tempi e scadenze di questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:173
+msgid "tempi_e_scadenze_help"
+msgstr ""
+
+#. Default: "Tempi e scadenze"
+#: design/plone/contenttypes/interfaces/servizio.py:413
+msgid "tempi_e_scadenze_label"
+msgstr ""
+
+#. Default: "Testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:51
+msgid "testata_fieldset_label"
+msgstr ""
+
 #. Default: "Tipologia documento"
-#: design/plone/contenttypes/interfaces/messaggio.py:54
+#: design/plone/contenttypes/interfaces/messaggio.py:50
 msgid "tipologia_documento"
 msgstr ""
 
@@ -1671,22 +1833,22 @@ msgid "tipologia_notizia_label"
 msgstr ""
 
 #. Default: "Tipologia organizzazione"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:79
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:54
 msgid "tipologia_organizzazione"
 msgstr ""
 
 #. Default: "Specificare la tipologia di organizzazione: politica, amminsitrativa o di altro tipo."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:85
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:57
 msgid "tipologia_organizzazione_help"
 msgstr ""
 
 #. Default: "Tipologia persona"
-#: design/plone/contenttypes/interfaces/persona.py:187
+#: design/plone/contenttypes/interfaces/persona.py:28
 msgid "tipologia_persona"
 msgstr ""
 
 #. Default: "Seleziona la tipologia di persona: politica, amministrativa o di altro tipo."
-#: design/plone/contenttypes/interfaces/persona.py:188
+#: design/plone/contenttypes/interfaces/persona.py:29
 msgid "tipologia_persona_help"
 msgstr ""
 
@@ -1696,22 +1858,22 @@ msgid "titolare"
 msgstr ""
 
 #. Default: "Ufficio responsabile del documento"
-#: design/plone/contenttypes/interfaces/documento.py:37
+#: design/plone/contenttypes/interfaces/documento.py:32
 msgid "ufficio_responsabile"
 msgstr ""
 
 #. Default: "Ufficio responsabile"
-#: design/plone/contenttypes/interfaces/documento_personale.py:71
+#: design/plone/contenttypes/interfaces/documento_personale.py:63
 msgid "ufficio_responsabile_documento_personale"
 msgstr ""
 
-#. Default: "Ufficio resposabile"
-#: design/plone/contenttypes/interfaces/servizio.py:222
+#. Default: "Ufficio responsabile"
+#: design/plone/contenttypes/interfaces/servizio.py:219
 msgid "ufficio_responsabile_erogazione"
 msgstr ""
 
 #. Default: "Seleziona l'ufficio responsabile dell'erogazione di questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:223
+#: design/plone/contenttypes/interfaces/servizio.py:220
 msgid "ufficio_responsabile_help"
 msgstr ""
 
@@ -1721,41 +1883,46 @@ msgid "ufficio_riferimento"
 msgstr ""
 
 #. Default: "Ulteriori informazioni"
-#: design/plone/contenttypes/behaviors/additional_help_infos.py:17
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:19
 msgid "ulteriori_informazioni"
 msgstr ""
 
 #. Default: "Ulteriori informazioni non contemplate dai campi precedenti."
-#: design/plone/contenttypes/behaviors/additional_help_infos.py:18
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:20
 msgid "ulteriori_informazioni_help"
 msgstr ""
 
+#. Default: "Unità amministrativa responsabile"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:28
+msgid "unita_amministrativa_responsabile"
+msgstr ""
+
+#. Default: "Seleziona la lista delle unità amministrative responsabili di questo argomento."
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:38
+msgid "unita_amministrativa_responsabile_help"
+msgstr ""
+
 #. Default: "Informazioni"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:167
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:98
 msgid "unteriori_informazioni"
 msgstr ""
 
-#. Default: "Eventuali contatti di supporto all'utente."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:174
-msgid "uo_box_aiuto_help"
-msgstr ""
-
 #. Default: "Descrizione dei compiti assegnati alla struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:18
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:19
 msgid "uo_competenze_help"
 msgstr ""
 
 #. Default: "Eventuali informazioni di contatto generiche"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:207
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:116
 msgid "uo_contact_info_description"
 msgstr ""
 
 #. Default: "Vincoli"
-#: design/plone/contenttypes/interfaces/servizio.py:202
+#: design/plone/contenttypes/interfaces/servizio.py:200
 msgid "vincoli"
 msgstr ""
 
 #. Default: "Descrizione degli eventuali vincoli presenti."
-#: design/plone/contenttypes/interfaces/servizio.py:204
+#: design/plone/contenttypes/interfaces/servizio.py:202
 msgid "vincoli_help"
 msgstr ""

--- a/src/design/plone/contenttypes/locales/it/LC_MESSAGES/design.plone.contenttypes.po
+++ b/src/design/plone/contenttypes/locales/it/LC_MESSAGES/design.plone.contenttypes.po
@@ -193,7 +193,7 @@ msgstr ""
 msgid "Dataset collegato"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:82
+#: design/plone/contenttypes/behaviors/configure.zcml:73
 msgid "Dataset correlati"
 msgstr ""
 
@@ -205,7 +205,7 @@ msgstr ""
 msgid "Denuncia crimini"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:130
+#: design/plone/contenttypes/behaviors/configure.zcml:121
 msgid "Descrizione estesa"
 msgstr ""
 
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Indicare le dimensioni delle lead image dei contenuti"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:141
+#: design/plone/contenttypes/behaviors/configure.zcml:132
 msgid "Info per la testata"
 msgstr ""
 
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Leggere"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:63
+#: design/plone/contenttypes/behaviors/configure.zcml:54
 msgid "Luoghi correlati"
 msgstr ""
 
@@ -435,7 +435,7 @@ msgid "Nazione"
 msgstr ""
 
 #. Default: "Nome e cognome"
-#: design/plone/contenttypes/restapi/services/types/get.py:106
+#: design/plone/contenttypes/restapi/services/types/get.py:96
 msgid "Nome e Cognome"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Servizi collegati"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:92
+#: design/plone/contenttypes/behaviors/configure.zcml:83
 msgid "Servizi correlati"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Struttura responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:102
+#: design/plone/contenttypes/behaviors/configure.zcml:93
 msgid "Strutture correlate"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Ufficio responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:112
+#: design/plone/contenttypes/behaviors/configure.zcml:103
 msgid "Ulteriori campi aiuto testuali"
 msgstr ""
 
@@ -983,9 +983,9 @@ msgid "copertura_geografica_label"
 msgstr ""
 
 #. Default: "Contenuti collegati"
-#: design/plone/contenttypes/behaviors/argomenti.py:44
 #: design/plone/contenttypes/behaviors/dataset_correlati.py:40
 #: design/plone/contenttypes/behaviors/luoghi_correlati.py:38
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:100
 msgid "correlati_label"
 msgstr ""
 
@@ -1354,11 +1354,6 @@ msgstr ""
 #: design/plone/contenttypes/behaviors/evento.py:199
 #: design/plone/contenttypes/schema_overrides.py:54
 msgid "informazioni_label"
-msgstr ""
-
-#. Default: "Categorization"
-#: design/plone/contenttypes/behaviors/argomenti.py:65
-msgid "label_schema_categorization"
 msgstr ""
 
 #. Default: "Selezionare la lista di strutture e/o uffici collegati a questa unità organizzativa."

--- a/src/design/plone/contenttypes/locales/it/LC_MESSAGES/design.plone.contenttypes.po
+++ b/src/design/plone/contenttypes/locales/it/LC_MESSAGES/design.plone.contenttypes.po
@@ -18,11 +18,11 @@ msgstr ""
 msgid "Abitazione"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:42
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:37
 msgid "Accesso al trasporto pubblico"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:70
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:62
 msgid "Accesso luoghi della cultura"
 msgstr ""
 
@@ -66,32 +66,27 @@ msgstr ""
 msgid "Anziano"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:254
+#: design/plone/contenttypes/interfaces/servizio.py:241
 msgid "Area"
-msgstr ""
-
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:20
-msgid "Area di appartenenza"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:53
 msgid "Area di parcheggio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:63
+#: design/plone/contenttypes/interfaces/documento.py:52
 msgid "Area responsabile"
 msgstr ""
 
 #: design/plone/contenttypes/behaviors/configure.zcml:45
-#: design/plone/contenttypes/behaviors/evento.py:61
 msgid "Argomenti"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:41
-msgid "Assessorati di riferimento"
+#: design/plone/contenttypes/behaviors/argomenti.py:27
+msgid "Argomenti correlati"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:98
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:70
 msgid "Assessore di riferimento"
 msgstr ""
 
@@ -107,8 +102,8 @@ msgstr ""
 msgid "Atto normativo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:82
-#: design/plone/contenttypes/interfaces/documento_personale.py:89
+#: design/plone/contenttypes/interfaces/documento.py:70
+#: design/plone/contenttypes/interfaces/documento_personale.py:83
 msgid "Autore"
 msgstr ""
 
@@ -116,19 +111,19 @@ msgstr ""
 msgid "Autorizzare"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:81
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:73
 msgid "Avvio impresa"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:82
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:74
 msgid "Avvio nuova attività professionale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:85
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:77
 msgid "Avvio/registrazione filiale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:96
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:86
 msgid "Bancarotta"
 msgstr ""
 
@@ -136,11 +131,11 @@ msgstr ""
 msgid "CAP"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:49
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:44
 msgid "Cambio di residenza/domicilio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:122
+#: design/plone/contenttypes/interfaces/documento.py:109
 msgid "Canale digitale al servizio collegato"
 msgstr ""
 
@@ -148,11 +143,11 @@ msgstr ""
 msgid "Canon 5D IV"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:93
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:83
 msgid "Chiusura filiale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:91
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:82
 msgid "Chiusura impresa e attività professionale"
 msgstr ""
 
@@ -160,15 +155,15 @@ msgstr ""
 msgid "Città"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:123
+#: design/plone/contenttypes/interfaces/persona.py:161
 msgid "Collegamenti organizzazione di I livello"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:152
+#: design/plone/contenttypes/interfaces/persona.py:190
 msgid "Collegamenti organizzazione di II livello"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:45
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:40
 msgid "Compravendita/affitto casa/edifici/terreni, costruzione o ristrutturazione casa/edificio	"
 msgstr ""
 
@@ -188,17 +183,17 @@ msgstr ""
 msgid "Cultura"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:140
-#: design/plone/contenttypes/interfaces/documento_personale.py:133
+#: design/plone/contenttypes/interfaces/documento.py:127
+#: design/plone/contenttypes/interfaces/documento_personale.py:125
 #: design/plone/contenttypes/profiles/default/types/Dataset.xml
 msgid "Dataset"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento_personale.py:137
+#: design/plone/contenttypes/interfaces/documento_personale.py:129
 msgid "Dataset collegato"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:65
+#: design/plone/contenttypes/behaviors/configure.zcml:82
 msgid "Dataset correlati"
 msgstr ""
 
@@ -206,8 +201,12 @@ msgstr ""
 msgid "Delegare"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:63
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:55
 msgid "Denuncia crimini"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:130
+msgid "Descrizione estesa"
 msgstr ""
 
 #: design/plone/contenttypes/configure.zcml:34
@@ -218,7 +217,7 @@ msgstr ""
 msgid "Design Plone: Content-types (uninstall)"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:66
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:58
 msgid "Dichiarazione dei redditi, versamento e riscossione tributi/imposte e contributi"
 msgstr ""
 
@@ -226,7 +225,7 @@ msgstr ""
 msgid "Documenti albo pretorio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:278
+#: design/plone/contenttypes/interfaces/servizio.py:254
 #: design/plone/contenttypes/profiles/default/types/Documento.xml
 msgid "Documento"
 msgstr ""
@@ -245,10 +244,6 @@ msgstr ""
 
 #: design/plone/contenttypes/vocabularies/document_types_vocabulary.py:34
 msgid "Documento funzionamento interno"
-msgstr ""
-
-#: design/plone/contenttypes/interfaces/servizio.py:387
-msgid "Dove trovarci"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/dataset.py:31
@@ -270,11 +265,7 @@ msgstr ""
 msgid "Energia"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:247
-msgid "Evento figlio"
-msgstr ""
-
-#: design/plone/contenttypes/behaviors/evento.py:224
+#: design/plone/contenttypes/behaviors/evento.py:150
 msgid "Evento supportato da"
 msgstr ""
 
@@ -286,7 +277,7 @@ msgstr ""
 msgid "Fanciullo"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:86
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:78
 msgid "Finanziamento impresa"
 msgstr ""
 
@@ -303,7 +294,7 @@ msgstr ""
 msgid "Gestione dei rifiuti"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:87
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:79
 msgid "Gestione personale"
 msgstr ""
 
@@ -333,6 +324,10 @@ msgstr ""
 
 #: design/plone/contenttypes/controlpanels/vocabularies.py:35
 msgid "Indicare le dimensioni delle lead image dei contenuti"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:141
+msgid "Info per la testata"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/lista_azioni_pratica.py:33
@@ -367,7 +362,7 @@ msgstr ""
 msgid "Integrazione sociale"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:34
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:29
 msgid "Invalidità"
 msgstr ""
 
@@ -375,7 +370,7 @@ msgstr ""
 msgid "Iscriversi"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:30
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:25
 msgid "Iscrizione scuola/università e/o richiesta borsa di studio"
 msgstr ""
 
@@ -395,19 +390,15 @@ msgstr ""
 msgid "Leggere"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:55
+#: design/plone/contenttypes/behaviors/configure.zcml:63
 msgid "Luoghi correlati"
-msgstr ""
-
-#: design/plone/contenttypes/behaviors/evento.py:128
-msgid "Luogo dell'evento"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:47
 msgid "Matrimonio"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:60
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:52
 msgid "Matrimonio e/o cambio stato civile"
 msgstr ""
 
@@ -431,11 +422,11 @@ msgstr ""
 msgid "Modulistica"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:61
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:53
 msgid "Morte ed eredità"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:58
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:51
 msgid "Nascita di un bambino, richiesta adozioni"
 msgstr ""
 
@@ -443,24 +434,29 @@ msgstr ""
 msgid "Nazione"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:89
+#. Default: "Nome e cognome"
+#: design/plone/contenttypes/restapi/services/types/get.py:106
+msgid "Nome e Cognome"
+msgstr ""
+
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:81
 msgid "Notifiche autorità"
 msgstr ""
 
 #. Default: "Organizzato da (interno)"
-#: design/plone/contenttypes/behaviors/evento.py:172
+#: design/plone/contenttypes/behaviors/evento.py:122
 msgid "Organizzato da_interno"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:177
+#: design/plone/contenttypes/behaviors/evento.py:125
 msgid "Organizzatore"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:45
+#: design/plone/contenttypes/interfaces/persona.py:105
 msgid "Organizzazione di riferimento"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:88
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:80
 msgid "Pagamento tasse, iva e dogane"
 msgstr ""
 
@@ -476,11 +472,11 @@ msgstr ""
 msgid "Paperino"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:99
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:89
 msgid "Partecipazione ad appalti pubblici nazionali e trasfrontalieri"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:39
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:34
 msgid "Pensionamento"
 msgstr ""
 
@@ -488,11 +484,11 @@ msgstr ""
 msgid "Persona"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:109
-msgid "Persona dell'amminnistrazione"
+#: design/plone/contenttypes/behaviors/evento.py:43
+msgid "Persona dell'amministrazione"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:125
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:87
 msgid "Persone della struttura"
 msgstr ""
 
@@ -512,7 +508,7 @@ msgstr ""
 msgid "Popolazione e società"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:73
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:65
 msgid "Possesso, cura, smarrimento animale da compagnia"
 msgstr ""
 
@@ -520,7 +516,7 @@ msgstr ""
 msgid "Pratica"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:62
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:54
 msgid "Prenotazione e disdetta visite/esami"
 msgstr ""
 
@@ -532,23 +528,23 @@ msgstr ""
 msgid "Regioni e città"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:84
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:76
 msgid "Registrazione impresa transfrontalier"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:41
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:36
 msgid "Registrazione/possesso veicolo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:57
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:43
 msgid "Responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/persona.py:70
+#: design/plone/contenttypes/interfaces/persona.py:130
 msgid "Responsabile di"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:37
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:32
 msgid "Ricerca di lavoro, avvio nuovo lavoro, disoccupazione"
 msgstr ""
 
@@ -560,19 +556,19 @@ msgstr ""
 msgid "Richiedere"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:83
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:75
 msgid "Richiesta licenze/permessi/certificati"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:40
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:35
 msgid "Richiesta o rinnovo patente"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:53
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:47
 msgid "Richiesta passaporto, visto e assistenza viaggi internazionali"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:94
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:84
 msgid "Ristrutturazione impresa"
 msgstr ""
 
@@ -585,15 +581,15 @@ msgstr ""
 msgid "Scienza e tecnologia"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:188
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:108
 msgid "Sede"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:364
+#: design/plone/contenttypes/interfaces/servizio.py:319
 msgid "Servizi collegati"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:75
+#: design/plone/contenttypes/behaviors/configure.zcml:92
 msgid "Servizi correlati"
 msgstr ""
 
@@ -601,8 +597,8 @@ msgstr ""
 msgid "Servizio"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/documento.py:106
-#: design/plone/contenttypes/interfaces/documento_personale.py:104
+#: design/plone/contenttypes/interfaces/documento.py:94
+#: design/plone/contenttypes/interfaces/documento_personale.py:98
 msgid "Servizio collegato"
 msgstr ""
 
@@ -626,16 +622,20 @@ msgstr ""
 msgid "Sport"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:34
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:35
 msgid "Struttura"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/evento.py:274
+#: design/plone/contenttypes/behaviors/strutture_correlate.py:20
 msgid "Struttura politica coinvolta"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/luogo.py:116
+#: design/plone/contenttypes/behaviors/luogo.py:124
 msgid "Struttura responsabile"
+msgstr ""
+
+#: design/plone/contenttypes/behaviors/configure.zcml:102
+msgid "Strutture correlate"
 msgstr ""
 
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:30
@@ -678,11 +678,11 @@ msgstr ""
 msgid "Turismo"
 msgstr ""
 
-#: design/plone/contenttypes/interfaces/servizio.py:231
+#: design/plone/contenttypes/interfaces/servizio.py:228
 msgid "Ufficio responsabile"
 msgstr ""
 
-#: design/plone/contenttypes/behaviors/configure.zcml:85
+#: design/plone/contenttypes/behaviors/configure.zcml:112
 msgid "Ulteriori campi aiuto testuali"
 msgstr ""
 
@@ -694,11 +694,15 @@ msgstr ""
 msgid "Unita Organizzativa"
 msgstr ""
 
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:35
+msgid "Unità amministrativa responsabile"
+msgstr ""
+
 #: design/plone/contenttypes/vocabularies/tags_vocabulary.py:38
 msgid "Urbanistica ed edilizia"
 msgstr ""
 
-#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:95
+#: design/plone/contenttypes/vocabularies/all_life_events_vocabulary.py:85
 msgid "Vendita impresa"
 msgstr ""
 
@@ -720,24 +724,39 @@ msgstr ""
 msgid "Vocabolari Design Plone"
 msgstr ""
 
+#. Default: "A chi si rivolge questo servizio e chi può usufruirne."
+#: design/plone/contenttypes/interfaces/servizio.py:57
+msgid "a_chi_si_rivolge_help"
+msgstr ""
+
+#. Default: "A chi si rivolge"
+#: design/plone/contenttypes/interfaces/servizio.py:55
+msgid "a_chi_si_rivolge_label"
+msgstr ""
+
 #. Default: "Seleziona l'ufficio di comunicazione responsabile di questa notizia/comunicato stampa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:39
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:38
 msgid "a_cura_di_help"
 msgstr ""
 
 #. Default: "A cura di"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:38
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:37
 msgid "a_cura_di_label"
 msgstr ""
 
 #. Default: "Seleziona una lista di persone dell'amministrazione citate in questa notizia/comunicato stampa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:51
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:50
 msgid "a_cura_di_persone_help"
 msgstr ""
 
 #. Default: "Persone"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:50
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:49
 msgid "a_cura_di_persone_label"
+msgstr ""
+
+#. Default: "Accedi al servizio"
+#: design/plone/contenttypes/interfaces/servizio.py:388
+msgid "accedi_al_servizio_label"
 msgstr ""
 
 #. Default: "Allegato"
@@ -746,77 +765,67 @@ msgid "allegato"
 msgstr ""
 
 #. Default: "Seleziona la lista dei documenti di supporto collegati a questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:272
+#: design/plone/contenttypes/interfaces/servizio.py:248
 msgid "altri_documenti_help"
 msgstr ""
 
 #. Default: "Area"
-#: design/plone/contenttypes/interfaces/servizio.py:246
+#: design/plone/contenttypes/interfaces/servizio.py:234
 msgid "area"
 msgstr ""
 
-#. Default: "Area di appartenenza"
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:16
-msgid "area_di_appartenenza"
-msgstr ""
-
 #. Default: "Seleziona l'area da cui dipende questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:249
+#: design/plone/contenttypes/interfaces/servizio.py:237
 msgid "area_help"
 msgstr ""
 
 #. Default: "Area responsabile del documento"
-#: design/plone/contenttypes/interfaces/documento.py:58
+#: design/plone/contenttypes/interfaces/documento.py:49
 msgid "area_responsabile"
 msgstr ""
 
 #. Default: "Area responsabile"
-#: design/plone/contenttypes/interfaces/documento_personale.py:79
+#: design/plone/contenttypes/interfaces/documento_personale.py:73
 msgid "area_responsabile_documento_personale"
 msgstr ""
 
 #. Default: "Argomenti utenti"
-#: design/plone/contenttypes/interfaces/documento_personale.py:46
+#: design/plone/contenttypes/interfaces/documento_personale.py:43
 msgid "argomenti_utenti"
 msgstr ""
 
-#. Default: "Assessorati di riferimento"
-#: design/plone/contenttypes/interfaces/pagina_argomento.py:35
-msgid "assessorati_riferimento"
-msgstr ""
-
 #. Default: "Inserire l'assessore di riferimento della struttura, se esiste."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:101
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:73
 msgid "assessore_riferimento_help"
 msgstr ""
 
 #. Default: "Atto nomina"
-#: design/plone/contenttypes/interfaces/persona.py:252
+#: design/plone/contenttypes/interfaces/persona.py:244
 msgid "atto_nomina"
 msgstr ""
 
 #. Default: "Atto di nomina della persona."
-#: design/plone/contenttypes/interfaces/persona.py:254
+#: design/plone/contenttypes/interfaces/persona.py:246
 msgid "atto_nomina_help"
 msgstr ""
 
 #. Default: "Autenticazione"
-#: design/plone/contenttypes/interfaces/servizio.py:139
+#: design/plone/contenttypes/interfaces/servizio.py:125
 msgid "autenticazione"
 msgstr ""
 
 #. Default: "Indicare, se previste, le modalità di autenticazione necessarie per poter accedere al servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:140
+#: design/plone/contenttypes/interfaces/servizio.py:126
 msgid "autenticazione_help"
 msgstr ""
 
 #. Default: "Azioni"
-#: design/plone/contenttypes/interfaces/messaggio.py:30
+#: design/plone/contenttypes/interfaces/messaggio.py:28
 msgid "azioni_pratica"
 msgstr ""
 
 #. Default: "Azioni richieste"
-#: design/plone/contenttypes/interfaces/messaggio.py:24
+#: design/plone/contenttypes/interfaces/messaggio.py:22
 msgid "azioni_richieste"
 msgstr ""
 
@@ -826,151 +835,113 @@ msgid "azioni_utente"
 msgstr ""
 
 #. Default: "Biografia"
-#: design/plone/contenttypes/interfaces/persona.py:198
+#: design/plone/contenttypes/interfaces/persona.py:66
 msgid "biografia"
 msgstr ""
 
 #. Default: "Solo per persona politica: testo descrittivo che riporta la biografia della persona."
-#: design/plone/contenttypes/interfaces/persona.py:199
+#: design/plone/contenttypes/interfaces/persona.py:67
 msgid "biografia_help"
 msgstr ""
 
-#. Default: "Box di aiuto"
-#: design/plone/contenttypes/behaviors/evento.py:290
-#: design/plone/contenttypes/interfaces/documento.py:170
-#: design/plone/contenttypes/interfaces/documento_personale.py:153
-msgid "box_aiuto"
-msgstr ""
-
-#. Default: "Ulteriori informazioni sul Servizio, FAQ, eventuali riferimenti normativi ed eventuali contatti di supporto all'utente."
-#: design/plone/contenttypes/interfaces/servizio.py:352
-msgid "box_aiuto_help"
-msgstr ""
-
 #. Default: "Canale digitale"
-#: design/plone/contenttypes/interfaces/servizio.py:129
+#: design/plone/contenttypes/interfaces/servizio.py:115
 msgid "canale_digitale"
 msgstr ""
 
 #. Default: "Collegamento con l'eventuale canale digitale di attivazione del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:130
+#: design/plone/contenttypes/interfaces/servizio.py:116
 msgid "canale_digitale_help"
 msgstr ""
 
 #. Default: "Canale digitale servizio collegato"
-#: design/plone/contenttypes/interfaces/documento_personale.py:111
+#: design/plone/contenttypes/interfaces/documento_personale.py:104
 msgid "canale_digitale_servizio"
 msgstr ""
 
-#. Default: "Canale fisico"
-#: design/plone/contenttypes/interfaces/servizio.py:149
-msgid "canale_fisico"
-msgstr ""
-
-#. Default: "Indica le sedi dove è possibile usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:150
-msgid "canale_fisico_help"
-msgstr ""
-
-#. Default: "Canale fisico - prenotazione"
-#: design/plone/contenttypes/interfaces/servizio.py:158
-msgid "canale_fisico_prenotazione"
-msgstr ""
-
-#. Default: "Se è possibile prenotare un'appuntamento, indicare il collegamento al servizio di prenotazione appuntamenti del Comune."
-#: design/plone/contenttypes/interfaces/servizio.py:162
-msgid "canale_fisico_prenotazione_help"
-msgstr ""
-
-#. Default: "CAP"
-#: design/plone/contenttypes/behaviors/evento.py:153
-msgid "cap"
-msgstr ""
-
 #. Default: "Casi particolari"
-#: design/plone/contenttypes/interfaces/servizio.py:211
+#: design/plone/contenttypes/interfaces/servizio.py:208
 msgid "casi_particolari"
 msgstr ""
 
 #. Default: "Descrizione degli evetuali casi particolari riferiti alla fruibilità di questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:213
+#: design/plone/contenttypes/interfaces/servizio.py:210
 msgid "casi_particolari_help"
 msgstr ""
 
-#. Default: "Categoria prevalente"
-#: design/plone/contenttypes/behaviors/luogo.py:96
-msgid "categoria_prevalente"
-msgstr ""
-
-#. Default: "Chi può presentare"
-#: design/plone/contenttypes/interfaces/servizio.py:76
-msgid "chi_puo_presentare"
+#. Default: "Casi particolari"
+#: design/plone/contenttypes/interfaces/servizio.py:419
+msgid "casi_particolari_label"
 msgstr ""
 
 #. Default: "Descrizione di chi può presentare domanda per usufruire del servizio e delle diverse casistiche."
-#: design/plone/contenttypes/interfaces/servizio.py:78
+#: design/plone/contenttypes/interfaces/servizio.py:66
 msgid "chi_puo_presentare_help"
 msgstr ""
 
+#. Default: "Chi può presentare"
+#: design/plone/contenttypes/interfaces/servizio.py:64
+msgid "chi_puo_presentare_label"
+msgstr ""
+
 #. Default: "Circoscrizione"
-#: design/plone/contenttypes/behaviors/evento.py:150
-#: design/plone/contenttypes/behaviors/luogo.py:26
+#: design/plone/contenttypes/behaviors/luogo.py:32
 msgid "circoscrizione"
 msgstr ""
 
 #. Default: "Codice dell'ente erogatore (ipa)"
-#: design/plone/contenttypes/interfaces/servizio.py:319
+#: design/plone/contenttypes/interfaces/servizio.py:285
 msgid "codice_ipa"
 msgstr ""
 
 #. Default: "Specificare il nome dell’organizzazione, come indicato nell’Indice della Pubblica Amministrazione (IPA), che esercita uno specifico ruolo sul Servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:321
+#: design/plone/contenttypes/interfaces/servizio.py:287
 msgid "codice_ipa_help"
 msgstr ""
 
 #. Default: "Collegamenti all'organizzazione di I livello"
-#: design/plone/contenttypes/interfaces/persona.py:109
+#: design/plone/contenttypes/interfaces/persona.py:147
 msgid "collegamenti_organizzazione_l1"
 msgstr ""
 
 #. Default: "Seleziona l'organizzazione a cui la persona è collegata. Se si tratta di una persona politica, il collegamento è riferito a una struttura politica. Se si tratta di una persona amministrativa, il collegamento è riferito ad un'area amministrativa."
-#: design/plone/contenttypes/interfaces/persona.py:113
+#: design/plone/contenttypes/interfaces/persona.py:151
 msgid "collegamenti_organizzazione_l1_help"
 msgstr ""
 
 #. Default: "Collegamenti all'organizzazione di II livello"
-#: design/plone/contenttypes/interfaces/persona.py:140
+#: design/plone/contenttypes/interfaces/persona.py:178
 msgid "collegamenti_organizzazione_l2"
 msgstr ""
 
 #. Default: "Seleziona gli assessorati di cui la persona si occupa,  i gruppi politici, commissioni a cui appartiene, oppure gli uffici di cui si occupa o di cui è responsabile."
-#: design/plone/contenttypes/interfaces/persona.py:144
+#: design/plone/contenttypes/interfaces/persona.py:182
 msgid "collegamenti_organizzazione_l2_help"
 msgstr ""
 
 #. Default: "Come si fa"
-#: design/plone/contenttypes/interfaces/servizio.py:96
+#: design/plone/contenttypes/interfaces/servizio.py:84
 msgid "come_si_fa"
 msgstr ""
 
 #. Default: "Descrizione della procedura da seguire per poter usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:98
+#: design/plone/contenttypes/interfaces/servizio.py:86
 msgid "come_si_fa_help"
 msgstr ""
 
 #. Default: "Competenze"
-#: design/plone/contenttypes/interfaces/persona.py:169
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:17
+#: design/plone/contenttypes/interfaces/persona.py:207
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:18
 msgid "competenze"
 msgstr ""
 
 #. Default: "Descrizione del ruolo e dei compiti della persona."
-#: design/plone/contenttypes/interfaces/persona.py:170
+#: design/plone/contenttypes/interfaces/persona.py:208
 msgid "competenze_help"
 msgstr ""
 
 #. Default: "Informazioni di contatto generiche"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:203
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:114
 msgid "contact_info"
 msgstr ""
 
@@ -980,13 +951,20 @@ msgid "contatti"
 msgstr ""
 
 #. Default: "Contatti"
-#: design/plone/contenttypes/behaviors/luogo.py:149
+#: design/plone/contenttypes/behaviors/evento.py:189
+#: design/plone/contenttypes/behaviors/luogo.py:220
+#: design/plone/contenttypes/interfaces/servizio.py:425
 msgid "contatti_label"
 msgstr ""
 
-#. Default: "Contatto: reperibilità"
-#: design/plone/contenttypes/behaviors/evento.py:203
+#. Default: "Reperibilità organizzatore"
+#: design/plone/contenttypes/behaviors/evento.py:112
 msgid "contatto_reperibilita"
+msgstr ""
+
+#. Default: "Indicare gli orari in cui l'organizzatore è telefonicamente reperibile."
+#: design/plone/contenttypes/behaviors/evento.py:114
+msgid "contatto_reperibilita_help"
 msgstr ""
 
 #. Default: "Contenuto"
@@ -994,101 +972,116 @@ msgstr ""
 msgid "contenuto"
 msgstr ""
 
-#. Default: "Copertura geografica"
-#: design/plone/contenttypes/interfaces/servizio.py:86
-msgid "copertura_geografica"
-msgstr ""
-
 #. Default: "Indicare se il servizio si riferisce ad una particolare area geografica o all'intero territorio di riferimento."
-#: design/plone/contenttypes/interfaces/servizio.py:88
+#: design/plone/contenttypes/interfaces/servizio.py:76
 msgid "copertura_geografica_help"
 msgstr ""
 
-#. Default: "Correlati"
-#: design/plone/contenttypes/behaviors/argomenti.py:38
+#. Default: "Copertura geografica"
+#: design/plone/contenttypes/interfaces/servizio.py:74
+msgid "copertura_geografica_label"
+msgstr ""
+
+#. Default: "Contenuti collegati"
+#: design/plone/contenttypes/behaviors/argomenti.py:44
 #: design/plone/contenttypes/behaviors/dataset_correlati.py:40
-#: design/plone/contenttypes/behaviors/luoghi_correlati.py:39
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:38
 msgid "correlati_label"
 msgstr ""
 
 #. Default: "Cosa serve"
-#: design/plone/contenttypes/interfaces/servizio.py:183
+#: design/plone/contenttypes/interfaces/servizio.py:181
 msgid "cosa_serve"
 msgstr ""
 
 #. Default: "Descrizione delle istruzioni per usufruire del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:185
+#: design/plone/contenttypes/interfaces/servizio.py:183
 msgid "cosa_serve_help"
 msgstr ""
 
+#. Default: "Cosa serve"
+#: design/plone/contenttypes/interfaces/servizio.py:402
+msgid "cosa_serve_label"
+msgstr ""
+
 #. Default: "Cosa si ottiene"
-#: design/plone/contenttypes/interfaces/servizio.py:106
+#: design/plone/contenttypes/interfaces/servizio.py:94
 msgid "cosa_si_ottiene"
 msgstr ""
 
 #. Default: "Indicare cosa si può ottenere dal servizio, ad esempio 'carta di identità elettronica', 'certificato di residenza'."
-#: design/plone/contenttypes/interfaces/servizio.py:107
+#: design/plone/contenttypes/interfaces/servizio.py:95
 msgid "cosa_si_ottiene_help"
 msgstr ""
 
 #. Default: "Costi"
-#: design/plone/contenttypes/interfaces/servizio.py:192
+#: design/plone/contenttypes/interfaces/servizio.py:190
 msgid "costi"
 msgstr ""
 
+#. Default: "Costi e vincoli"
+#: design/plone/contenttypes/interfaces/servizio.py:407
+msgid "costi_e_vincoli_label"
+msgstr ""
+
 #. Default: "Descrizione delle condizioni e dei termini economici per completare la procedura di richiesta del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:194
+#: design/plone/contenttypes/interfaces/servizio.py:192
 msgid "costi_help"
 msgstr ""
 
+#. Default: "Costi"
+#: design/plone/contenttypes/behaviors/evento.py:186
+msgid "costi_label"
+msgstr ""
+
 #. Default: "Curriculum vitae"
-#: design/plone/contenttypes/interfaces/persona.py:232
+#: design/plone/contenttypes/interfaces/persona.py:224
 msgid "curriculum_vitae"
 msgstr ""
 
 #. Default: "Curriculum vitae della persona."
-#: design/plone/contenttypes/interfaces/persona.py:234
+#: design/plone/contenttypes/interfaces/persona.py:226
 msgid "curriculum_vitae_help"
 msgstr ""
 
 #. Default: "Data conclusione incarico"
-#: design/plone/contenttypes/interfaces/persona.py:98
+#: design/plone/contenttypes/interfaces/persona.py:57
 msgid "data_conclusione_incarico"
 msgstr ""
 
 #. Default: "Data di conclusione dell'incarico."
-#: design/plone/contenttypes/interfaces/persona.py:101
+#: design/plone/contenttypes/interfaces/persona.py:58
 msgid "data_conclusione_incarico_help"
 msgstr ""
 
 #. Default: "Data e fasi intermedie"
-#: design/plone/contenttypes/interfaces/documento_personale.py:123
+#: design/plone/contenttypes/interfaces/documento_personale.py:115
 msgid "data_e_fasi_intermedie"
 msgstr ""
 
 #. Default: "Data di scadenza"
-#: design/plone/contenttypes/interfaces/documento.py:133
+#: design/plone/contenttypes/interfaces/documento.py:120
 msgid "data_fine"
 msgstr ""
 
 #. Default: "Data di inizio"
-#: design/plone/contenttypes/interfaces/documento.py:127
-#: design/plone/contenttypes/interfaces/documento_personale.py:119
+#: design/plone/contenttypes/interfaces/documento.py:114
+#: design/plone/contenttypes/interfaces/documento_personale.py:111
 msgid "data_inizio"
 msgstr ""
 
 #. Default: "Data insediamento"
-#: design/plone/contenttypes/interfaces/persona.py:88
+#: design/plone/contenttypes/interfaces/persona.py:47
 msgid "data_insediamento"
 msgstr ""
 
 #. Default: "Solo per persona politica: specificare la data di insediamento."
-#: design/plone/contenttypes/interfaces/persona.py:89
+#: design/plone/contenttypes/interfaces/persona.py:48
 msgid "data_insediamento_help"
 msgstr ""
 
 #. Default: "Data del messaggio"
-#: design/plone/contenttypes/interfaces/messaggio.py:14
+#: design/plone/contenttypes/interfaces/messaggio.py:13
 msgid "data_messaggio"
 msgstr ""
 
@@ -1098,13 +1091,13 @@ msgid "data_pagamento"
 msgstr ""
 
 #. Default: "Data del protocollo"
-#: design/plone/contenttypes/interfaces/documento.py:165
+#: design/plone/contenttypes/interfaces/documento.py:149
 #: design/plone/contenttypes/interfaces/documento_personale.py:20
 msgid "data_protocollo"
 msgstr ""
 
 #. Default: "Data di scadenza della procedura"
-#: design/plone/contenttypes/interfaces/messaggio.py:45
+#: design/plone/contenttypes/interfaces/messaggio.py:42
 msgid "data_scadenza_procedura"
 msgstr ""
 
@@ -1123,46 +1116,44 @@ msgstr ""
 msgid "dataset_correlati_label"
 msgstr ""
 
-#. Default: "Date significative"
-#: design/plone/contenttypes/behaviors/evento.py:156
-msgid "date_significative"
+#. Default: "Date dell'evento"
+#: design/plone/contenttypes/behaviors/evento.py:204
+#: design/plone/contenttypes/schema_overrides.py:35
+msgid "date_evento_label"
 msgstr ""
 
 #. Default: "Deleghe"
-#: design/plone/contenttypes/interfaces/persona.py:178
+#: design/plone/contenttypes/interfaces/persona.py:216
 msgid "deleghe"
 msgstr ""
 
 #. Default: "Elenco delle deleghe a capo della persona."
-#: design/plone/contenttypes/interfaces/persona.py:179
+#: design/plone/contenttypes/interfaces/persona.py:217
 msgid "deleghe_help"
 msgstr ""
 
-#. Default: "Descrizione breve"
-#: design/plone/contenttypes/behaviors/luogo.py:30
-msgid "descrizione_breve"
+#. Default: "Descrizione completa"
+#: design/plone/contenttypes/behaviors/luogo.py:42
+msgid "descrizione_completa"
 msgstr ""
 
 #. Default: "Descrizione destinatari"
-#: design/plone/contenttypes/behaviors/evento.py:99
-#: design/plone/contenttypes/interfaces/servizio.py:64
+#: design/plone/contenttypes/behaviors/evento.py:31
 msgid "descrizione_destinatari"
 msgstr ""
 
-#. Default: "Descrizione dei principali interlocutori del servizio: a chi si rivolge e chi può usufruirne."
-#: design/plone/contenttypes/interfaces/servizio.py:68
+#. Default: "Descrizione dei principali interlocutori dell'evento."
+#: design/plone/contenttypes/behaviors/evento.py:33
 msgid "descrizione_destinatari_help"
 msgstr ""
 
 #. Default: "Descrizione estesa"
-#: design/plone/contenttypes/interfaces/documento.py:31
-#: design/plone/contenttypes/interfaces/documento_personale.py:58
-#: design/plone/contenttypes/interfaces/servizio.py:55
+#: design/plone/contenttypes/behaviors/descrizione_estesa.py:17
 msgid "descrizione_estesa"
 msgstr ""
 
-#. Default: "Descrizione dettagliata e completa del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:57
+#. Default: "Descrizione dettagliata e completa."
+#: design/plone/contenttypes/behaviors/descrizione_estesa.py:19
 msgid "descrizione_estesa_help"
 msgstr ""
 
@@ -1172,22 +1163,47 @@ msgid "distribuzione"
 msgstr ""
 
 #. Default: "Documenti allegati"
-#: design/plone/contenttypes/interfaces/messaggio.py:61
+#: design/plone/contenttypes/interfaces/messaggio.py:57
 msgid "documenti_allegati"
 msgstr ""
 
+#. Default: "Documenti"
+#: design/plone/contenttypes/interfaces/servizio.py:430
+msgid "documenti_label"
+msgstr ""
+
+#. Default: "Dove"
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:65
+msgid "dove_label"
+msgstr ""
+
+#. Default: "Dove rivolgersi: informazioni aggiuntive"
+#: design/plone/contenttypes/interfaces/servizio.py:147
+msgid "dove_rivolgersi_extra"
+msgstr ""
+
+#. Default: "Indicare eventuali informazioni aggiuntive riguardo al dove rivolgersi per questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:151
+msgid "dove_rivolgersi_extra_help"
+msgstr ""
+
+#. Default: "Seleziona una lista delle sedi e dei luoghi in cui è presente questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:139
+msgid "dove_rivolgersi_help"
+msgstr ""
+
 #. Default: "Elementi di interesse"
-#: design/plone/contenttypes/behaviors/luogo.py:38
+#: design/plone/contenttypes/behaviors/luogo.py:63
 msgid "elementi_di_interesse"
 msgstr ""
 
 #. Default: "Indirizzo email"
-#: design/plone/contenttypes/interfaces/persona.py:216
+#: design/plone/contenttypes/interfaces/persona.py:82
 msgid "email"
 msgstr ""
 
 #. Default: "Contatto mail della persona."
-#: design/plone/contenttypes/interfaces/persona.py:217
+#: design/plone/contenttypes/interfaces/persona.py:83
 msgid "email_help"
 msgstr ""
 
@@ -1196,23 +1212,8 @@ msgstr ""
 msgid "esito"
 msgstr ""
 
-#. Default: "Evento genitore"
-#: design/plone/contenttypes/behaviors/evento.py:68
-msgid "evento_genitore"
-msgstr ""
-
-#. Default: "Fasi e scadenze"
-#: design/plone/contenttypes/interfaces/servizio.py:172
-msgid "fasi_scadenze"
-msgstr ""
-
-#. Default: "Prevedere una data di scadenza del servizio. Se il servizio è diviso in fasi, descriverne modalità e tempistiche."
-#: design/plone/contenttypes/interfaces/servizio.py:174
-msgid "fasi_scadenze_help"
-msgstr ""
-
 #. Default: "Foto da mostrare della persona; la dimensione suggerita è 180x100 px"
-#: design/plone/contenttypes/interfaces/persona.py:20
+#: design/plone/contenttypes/interfaces/persona.py:21
 msgid "foto_persona_help"
 msgstr ""
 
@@ -1226,8 +1227,78 @@ msgstr ""
 msgid "geolocation_field_validator_label"
 msgstr ""
 
+#. Default: "Indicare l'eventuale circoscrizione in cui si trova questo luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:33
+msgid "help_circoscrizione"
+msgstr ""
+
+#. Default: "Indicare una descrizione completa, inserendo tutte le informazioni rilevanti relative al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:43
+msgid "help_descrizione_completa"
+msgstr ""
+
+#. Default: "Indicare eventuali elementi di interesse relativi al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:64
+msgid "help_elementi_di_interesse"
+msgstr ""
+
+#. Default: "Indicare tutte le informazioni relative alla modalità di accesso al luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:73
+msgid "help_modalita_accesso"
+msgstr ""
+
+#. Default: "Indicare, se esiste, un nome alternativo per il luogo; questo sarà mostrato tra parentesi affiancato al titolo della scheda"
+#: design/plone/contenttypes/behaviors/luogo.py:53
+msgid "help_nome_alternativo"
+msgstr ""
+
+#. Default: "Indicare eventuali orari di accesso al pubblico"
+#: design/plone/contenttypes/behaviors/luogo.py:105
+msgid "help_orario_pubblico"
+msgstr ""
+
+#. Default: "Indicare l'eventuale quartiere in cui si trova questo luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:24
+msgid "help_quartiere"
+msgstr ""
+
+#. Default: "Indicare un indirizzo mail per poter contattare i referenti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:95
+msgid "help_riferimento_mail_luogo"
+msgstr ""
+
+#. Default: "Indicare un indirizzo mail per poter contattare i referenti della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:170
+msgid "help_riferimento_mail_struttura"
+msgstr ""
+
+#. Default: "Indicare un riferimento telefonico per poter contattare i referenti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:85
+msgid "help_riferimento_telefonico_luogo"
+msgstr ""
+
+#. Default: "Indicare il riferimento telefonico per poter contattare i referenti della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:157
+msgid "help_riferimento_telefonico_struttura"
+msgstr ""
+
+#. Default: "Indicare un indirizzo web utile per ottenere i contatti del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:180
+msgid "help_riferimento_web"
+msgstr ""
+
+#. Default: "Icona"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:17
+msgid "icona"
+msgstr ""
+
+#. Default: "Puoi selezionare un’icona fra quelle proposte nel menu a tendina oppure puoi scrivere/incollare nel campo di testo il nome di un’icona di fontawsome 5"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:18
+msgid "icona_help"
+msgstr ""
+
 #. Default: "Identificativo"
-#: design/plone/contenttypes/interfaces/servizio.py:341
+#: design/plone/contenttypes/interfaces/servizio.py:307
 msgid "identificativo"
 msgstr ""
 
@@ -1237,24 +1308,14 @@ msgid "identificativo_documento"
 msgstr ""
 
 #. Default: "Eventuale codice identificativo del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:343
+#: design/plone/contenttypes/interfaces/servizio.py:309
 msgid "identificativo_help"
 msgstr ""
 
-#. Default: "Identificativo"
-#: design/plone/contenttypes/behaviors/luogo.py:106
-msgid "identificativo_mibac"
-msgstr ""
-
-#. Default: "Identifier"
-#: design/plone/contenttypes/behaviors/evento.py:46
-msgid "identifier"
-msgstr ""
-
 #. Default: "Immagine"
-#: design/plone/contenttypes/behaviors/evento.py:54
 #: design/plone/contenttypes/interfaces/documento.py:23
 #: design/plone/contenttypes/interfaces/documento_personale.py:24
+#: design/plone/contenttypes/interfaces/persona.py:19
 msgid "immagine"
 msgstr ""
 
@@ -1263,33 +1324,45 @@ msgstr ""
 msgid "importo_pagato"
 msgstr ""
 
-#. Default: "Indirizzo"
-#: design/plone/contenttypes/behaviors/evento.py:142
-msgid "indirizzo"
+#. Default: "Inserisci eventuale testo informativo che verrà mostrato in testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:23
+msgid "info_testata_help"
+msgstr ""
+
+#. Default: "Informazioni aggiuntive per la testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:18
+msgid "info_testata_label"
 msgstr ""
 
 #. Default: "Ulteriori informazioni"
-#: design/plone/contenttypes/interfaces/documento_personale.py:143
+#: design/plone/contenttypes/interfaces/documento_personale.py:134
 msgid "informazioni"
 msgstr ""
 
 #. Default: "Informazioni di contatto"
-#: design/plone/contenttypes/interfaces/persona.py:221
+#: design/plone/contenttypes/interfaces/persona.py:88
 msgid "informazioni_di_contatto"
 msgstr ""
 
 #. Default: "Altre informazioni di contatto."
-#: design/plone/contenttypes/interfaces/persona.py:224
+#: design/plone/contenttypes/interfaces/persona.py:89
 msgid "informazioni_di_contatto_help"
 msgstr ""
 
-#. Default: "Introduzione"
-#: design/plone/contenttypes/behaviors/evento.py:92
-msgid "introduzione"
+#. Default: "Ulteriori informazioni"
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:29
+#: design/plone/contenttypes/behaviors/evento.py:199
+#: design/plone/contenttypes/schema_overrides.py:54
+msgid "informazioni_label"
+msgstr ""
+
+#. Default: "Categorization"
+#: design/plone/contenttypes/behaviors/argomenti.py:65
+msgid "label_schema_categorization"
 msgstr ""
 
 #. Default: "Selezionare la lista di strutture e/o uffici collegati a questa unità organizzativa."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:28
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:29
 msgid "legami_con_altre_strutture_help"
 msgstr ""
 
@@ -1299,30 +1372,40 @@ msgid "licenza"
 msgstr ""
 
 #. Default: "Licenza di distribuzione"
-#: design/plone/contenttypes/interfaces/documento.py:97
-#: design/plone/contenttypes/interfaces/documento_personale.py:95
+#: design/plone/contenttypes/interfaces/documento.py:85
+#: design/plone/contenttypes/interfaces/documento_personale.py:89
 msgid "licenza_distribuzione"
 msgstr ""
 
 #. Default: "Parte del life event"
-#: design/plone/contenttypes/interfaces/documento.py:177
-#: design/plone/contenttypes/interfaces/servizio.py:307
+#: design/plone/contenttypes/interfaces/documento.py:156
+#: design/plone/contenttypes/interfaces/servizio.py:273
 msgid "life_event"
 msgstr ""
 
 #. Default: "Collegamento tra il servizio e un evento della vita di una persona o di un'impresa. Ad esempio: il servizio 'Anagrafe' è collegato alla nascita di un bambino"
-#: design/plone/contenttypes/interfaces/servizio.py:308
+#: design/plone/contenttypes/interfaces/servizio.py:274
 msgid "life_event_help"
 msgstr ""
 
 #. Default: "Link a siti esterni"
-#: design/plone/contenttypes/interfaces/servizio.py:294
+#: design/plone/contenttypes/interfaces/servizio.py:260
 msgid "link_siti_esterni"
 msgstr ""
 
 #. Default: "Eventuali collegamenti a pagine web, siti, servizi esterni all'ambito Comunale utili all'erogazione del servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:296
+#: design/plone/contenttypes/interfaces/servizio.py:262
 msgid "link_siti_esterni_help"
+msgstr ""
+
+#. Default: "Link utili"
+#: design/plone/contenttypes/interfaces/servizio.py:435
+msgid "link_utili_label"
+msgstr ""
+
+#. Default: "Luoghi dell'evento"
+#: design/plone/contenttypes/behaviors/luoghi_correlati.py:56
+msgid "luoghi_correlati_evento_label"
 msgstr ""
 
 #. Default: "Seleziona una lista di luoghi citati."
@@ -1335,13 +1418,8 @@ msgstr ""
 msgid "luoghi_correlati_label"
 msgstr ""
 
-#. Default: "Luogo dell'evento"
-#: design/plone/contenttypes/behaviors/evento.py:125
-msgid "luogo_evento"
-msgstr ""
-
 #. Default: "Modalita' di accesso"
-#: design/plone/contenttypes/behaviors/luogo.py:43
+#: design/plone/contenttypes/behaviors/luogo.py:72
 msgid "modalita_accesso"
 msgstr ""
 
@@ -1350,33 +1428,43 @@ msgstr ""
 msgid "modalita_pagamento"
 msgstr ""
 
-#. Default: "Motivo dello stato del servizio nel caso non sia attivo"
-#: design/plone/contenttypes/interfaces/servizio.py:33
-msgid "motivo_stato_servizio"
+#. Default: "Seleziona se mostrare o meno la navigazione laterale nella testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:43
+msgid "mostra_navigazione_help"
+msgstr ""
+
+#. Default: "Mostra la navigazione"
+#: design/plone/contenttypes/behaviors/info_testata.py:40
+msgid "mostra_navigazione_label"
 msgstr ""
 
 #. Default: "Descrizione del motivo per cui il servizio non è attivo."
-#: design/plone/contenttypes/interfaces/servizio.py:38
+#: design/plone/contenttypes/interfaces/servizio.py:48
 msgid "motivo_stato_servizio_help"
 msgstr ""
 
+#. Default: "Motivo dello stato del servizio nel caso non sia attivo"
+#: design/plone/contenttypes/interfaces/servizio.py:43
+msgid "motivo_stato_servizio_label"
+msgstr ""
+
 #. Default: "Nome alternativo"
-#: design/plone/contenttypes/behaviors/luogo.py:34
+#: design/plone/contenttypes/behaviors/luogo.py:52
 msgid "nome_alternativo"
 msgstr ""
 
 #. Default: "Seleziona una lista di notizie correlate a questa."
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:63
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:62
 msgid "notizie_correlate_help"
 msgstr ""
 
 #. Default: "Notizie correlate"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:62
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:61
 msgid "notizie_correlate_label"
 msgstr ""
 
 #. Default: "Numero progressivo del comunicato stampa"
-#: design/plone/contenttypes/behaviors/news_additional_fields.py:30
+#: design/plone/contenttypes/behaviors/news_additional_fields.py:29
 msgid "numero_progressivo_cs_label"
 msgstr ""
 
@@ -1387,48 +1475,78 @@ msgid "numero_protocollo"
 msgstr ""
 
 #. Default: "Oggetto"
-#: design/plone/contenttypes/interfaces/documento_personale.py:52
+#: design/plone/contenttypes/interfaces/documento_personale.py:49
 msgid "oggetto"
 msgstr ""
 
-#. Default: "Orari"
-#: design/plone/contenttypes/behaviors/evento.py:160
+#. Default: "Informazioni sugli orari"
+#: design/plone/contenttypes/behaviors/evento.py:82
 msgid "orari"
 msgstr ""
 
+#. Default: "Informazioni sugli orari di svolgimento dell'evento."
+#: design/plone/contenttypes/behaviors/evento.py:84
+msgid "orari_help"
+msgstr ""
+
 #. Default: "Orario per il pubblico"
-#: design/plone/contenttypes/behaviors/luogo.py:59
+#: design/plone/contenttypes/behaviors/luogo.py:104
 msgid "orario_pubblico"
 msgstr ""
 
 #. Default: "Organizzato da"
-#: design/plone/contenttypes/behaviors/evento.py:167
+#: design/plone/contenttypes/behaviors/evento.py:102
 msgid "organizzato_da_esterno"
 msgstr ""
 
+#. Default: "Se l'evento non è organizzato direttamente dal comune, indicare l'organizzatore."
+#: design/plone/contenttypes/behaviors/evento.py:104
+msgid "organizzato_da_esterno_help"
+msgstr ""
+
+#. Default: "Se l'evento è organizzato direttamente dal comune, indicare l'ufficio/ente organizzatore."
+#: design/plone/contenttypes/behaviors/evento.py:128
+msgid "organizzato_da_interno_help"
+msgstr ""
+
 #. Default: "Organizzazione di riferimento"
-#: design/plone/contenttypes/interfaces/persona.py:35
+#: design/plone/contenttypes/interfaces/persona.py:96
 msgid "organizzazione_riferimento"
 msgstr ""
 
 #. Default: "Seleziona una lista di organizzazioni a cui la persona appartiene."
-#: design/plone/contenttypes/interfaces/persona.py:39
+#: design/plone/contenttypes/interfaces/persona.py:99
 msgid "organizzazione_riferimento_help"
 msgstr ""
 
+#. Default: "Partecipanti"
+#: design/plone/contenttypes/behaviors/evento.py:183
+msgid "partecipanti_label"
+msgstr ""
+
 #. Default: "Patrocinato da"
-#: design/plone/contenttypes/behaviors/evento.py:263
+#: design/plone/contenttypes/behaviors/evento.py:172
 msgid "patrocinato_da"
 msgstr ""
 
+#. Default: "Indicare l'ente che supporta l'evento, se presente."
+#: design/plone/contenttypes/behaviors/evento.py:174
+msgid "patrocinato_da_help"
+msgstr ""
+
+#. Default: "Elenco delle persone dell'amministrazione che parteciperanno all'evento."
+#: design/plone/contenttypes/behaviors/evento.py:46
+msgid "persone_amministrazione_help"
+msgstr ""
+
 #. Default: "Seleziona la lista delle persone che compongono la struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:128
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:90
 msgid "persone_struttura_help"
 msgstr ""
 
 #. Default: "Pratica associata"
 #: design/plone/contenttypes/interfaces/documento_personale.py:28
-#: design/plone/contenttypes/interfaces/messaggio.py:37
+#: design/plone/contenttypes/interfaces/messaggio.py:35
 msgid "pratica_associata"
 msgstr ""
 
@@ -1437,106 +1555,120 @@ msgstr ""
 msgid "pratica_associata_ricevuta"
 msgstr ""
 
+#. Default: "Prenota un appuntamento"
+#: design/plone/contenttypes/interfaces/servizio.py:160
+msgid "prenota_appuntamento"
+msgstr ""
+
+#. Default: "Se è possibile prenotare un'appuntamento, indicare le informazioni necessarie e il collegamento al servizio di prenotazione appuntamenti del Comune."
+#: design/plone/contenttypes/interfaces/servizio.py:161
+msgid "prenota_appuntamento_help"
+msgstr ""
+
 #. Default: "Prezzo"
-#: design/plone/contenttypes/behaviors/evento.py:164
+#: design/plone/contenttypes/behaviors/evento.py:92
 msgid "prezzo"
 msgstr ""
 
+#. Default: "Indicare il prezzo dell'evento, se presente, specificando se esistono formati diversi."
+#: design/plone/contenttypes/behaviors/evento.py:94
+msgid "prezzo_help"
+msgstr ""
+
 #. Default: "Procedure collegate all'esito"
-#: design/plone/contenttypes/interfaces/servizio.py:116
+#: design/plone/contenttypes/interfaces/servizio.py:104
 msgid "procedure_collegate"
 msgstr ""
 
 #. Default: "Indicare cosa deve fare l'utente del servizio per conoscere l'esito della procedura, e dove eventualmente poter ritirare l'esito."
-#: design/plone/contenttypes/interfaces/servizio.py:120
+#: design/plone/contenttypes/interfaces/servizio.py:106
 msgid "procedure_collegate_help"
 msgstr ""
 
 #. Default: "Protocollo"
-#: design/plone/contenttypes/interfaces/documento.py:161
+#: design/plone/contenttypes/interfaces/documento.py:145
 #: design/plone/contenttypes/interfaces/documento_personale.py:16
 msgid "protocollo"
 msgstr ""
 
 #. Default: "Quartiere"
-#: design/plone/contenttypes/behaviors/evento.py:146
-#: design/plone/contenttypes/behaviors/luogo.py:22
+#: design/plone/contenttypes/behaviors/luogo.py:23
 msgid "quartiere"
 msgstr ""
 
 #. Default: "Responsabile di"
-#: design/plone/contenttypes/interfaces/persona.py:63
+#: design/plone/contenttypes/interfaces/persona.py:123
 msgid "responsabile_di"
 msgstr ""
 
 #. Default: "Seleziona una lista di organizzazioni di cui la persona è responsabile."
-#: design/plone/contenttypes/interfaces/persona.py:64
+#: design/plone/contenttypes/interfaces/persona.py:124
 msgid "responsabile_di_help"
 msgstr ""
 
 #. Default: "Selezionare il/i responsabile/i della struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:60
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:45
 msgid "responsabile_help"
 msgstr ""
 
+#. Default: "Seleziona se mostrare o meno il campo di ricerca in testata."
+#: design/plone/contenttypes/behaviors/info_testata.py:33
+msgid "ricerca_in_testata_help"
+msgstr ""
+
+#. Default: "Ricerca in testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:30
+msgid "ricerca_in_testata_label"
+msgstr ""
+
 #. Default: "Riferimenti normativi"
-#: design/plone/contenttypes/interfaces/documento.py:156
-#: design/plone/contenttypes/interfaces/documento_personale.py:148
+#: design/plone/contenttypes/interfaces/documento.py:140
+#: design/plone/contenttypes/interfaces/documento_personale.py:138
 msgid "riferimenti_normativi"
 msgstr ""
 
 #. Default: "Riferimento mail luogo"
-#: design/plone/contenttypes/behaviors/luogo.py:54
+#: design/plone/contenttypes/behaviors/luogo.py:94
 msgid "riferimento_mail_luogo"
 msgstr ""
 
-#. Default: "Riferimento mail struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:81
+#. Default: "Riferimento mail della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:166
 msgid "riferimento_mail_struttura"
 msgstr ""
 
-#. Default: "Riferimento pec"
-#: design/plone/contenttypes/behaviors/luogo.py:124
-msgid "riferimento_pec"
-msgstr ""
-
 #. Default: "Riferimento telefonico luogo"
-#: design/plone/contenttypes/behaviors/luogo.py:47
+#: design/plone/contenttypes/behaviors/luogo.py:82
 msgid "riferimento_telefonico_luogo"
 msgstr ""
 
-#. Default: "Riferimento telefonico struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:73
+#. Default: "Riferimento telefonico della struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:153
 msgid "riferimento_telefonico_struttura"
 msgstr ""
 
 #. Default: "Riferimento sito web"
-#: design/plone/contenttypes/behaviors/luogo.py:89
+#: design/plone/contenttypes/behaviors/luogo.py:179
 msgid "riferimento_web"
 msgstr ""
 
 #. Default: "Ruolo"
-#: design/plone/contenttypes/interfaces/persona.py:26
+#: design/plone/contenttypes/interfaces/persona.py:39
 msgid "ruolo"
 msgstr ""
 
 #. Default: "Descrizione testuale del ruolo di questa persona."
-#: design/plone/contenttypes/interfaces/persona.py:27
+#: design/plone/contenttypes/interfaces/persona.py:40
 msgid "ruolo_help"
 msgstr ""
 
-#. Default: "Seleziona la lista delle sedi e dei luoghi collegati a questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:391
-msgid "sedi_e_luoghi_help"
-msgstr ""
-
 #. Default: "Seleziona una lista delle sedi di questa struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:183
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:104
 msgid "sedi_help"
 msgstr ""
 
 #. Default: "Seleziona la lista dei servizi collegati a questo."
-#: design/plone/contenttypes/interfaces/servizio.py:368
+#: design/plone/contenttypes/interfaces/servizio.py:322
 msgid "servizi_collegati_help"
 msgstr ""
 
@@ -1551,7 +1683,7 @@ msgid "servizi_correlati_label"
 msgstr ""
 
 #. Default: "Servizio che genera il documento"
-#: design/plone/contenttypes/interfaces/documento_personale.py:33
+#: design/plone/contenttypes/interfaces/documento_personale.py:32
 msgid "servizio_origine"
 msgstr ""
 
@@ -1566,23 +1698,23 @@ msgid "servizio_origine_ricevuta"
 msgstr ""
 
 #. Default: "Settore merceologico"
-#: design/plone/contenttypes/interfaces/servizio.py:331
+#: design/plone/contenttypes/interfaces/servizio.py:297
 msgid "settore_merceologico"
 msgstr ""
 
 #. Default: "Classificazione del servizio basata su catalogo dei servizi (Classificazione NACE)."
-#: design/plone/contenttypes/interfaces/servizio.py:333
+#: design/plone/contenttypes/interfaces/servizio.py:299
 msgid "settore_merceologico_help"
 msgstr ""
 
-#. Default: "Sottotitolo"
-#: design/plone/contenttypes/interfaces/servizio.py:45
-msgid "sottotitolo"
+#. Default: "Indica un eventuale sottotitolo/titolo alternativo per questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:22
+msgid "sottotitolo_help"
 msgstr ""
 
-#. Default: "Sponsor"
-#: design/plone/contenttypes/behaviors/evento.py:267
-msgid "sponsor"
+#. Default: "Sottotitolo"
+#: design/plone/contenttypes/interfaces/servizio.py:21
+msgid "sottotitolo_label"
 msgstr ""
 
 #. Default: "Stampa ricevuta"
@@ -1595,58 +1727,68 @@ msgstr ""
 msgid "stato_pratica"
 msgstr ""
 
-#. Default: "Servizio non attivo"
-#: design/plone/contenttypes/interfaces/servizio.py:24
-msgid "stato_servizio"
-msgstr ""
-
 #. Default: "Indica se il servizio è effettivamente fruibile."
-#: design/plone/contenttypes/interfaces/servizio.py:26
+#: design/plone/contenttypes/interfaces/servizio.py:36
 msgid "stato_servizio_help"
 msgstr ""
 
+#. Default: "Servizio non attivo"
+#: design/plone/contenttypes/interfaces/servizio.py:34
+msgid "stato_servizio_label"
+msgstr ""
+
 #. Default: "Struttura responsabile"
-#: design/plone/contenttypes/behaviors/luogo.py:63
+#: design/plone/contenttypes/behaviors/luogo.py:143
 msgid "struttura_responsabile"
 msgstr ""
 
+#. Default: "Struttura responsabile del luogo"
+#: design/plone/contenttypes/behaviors/luogo.py:113
+msgid "struttura_responsabile_correlati"
+msgstr ""
+
+#. Default: "Indicare la struttura responsabile del luogo qualora sia fra unità organizzative del comune inserite nel sito; altrimenti compilare i campi testuali relativi alla struttura responsabile"
+#: design/plone/contenttypes/behaviors/luogo.py:117
+msgid "struttura_responsabile_correlati_help"
+msgstr ""
+
 #. Default: "Nome/link al sito web della struttura che gestisce il luogo, se questa non è comunale."
-#: design/plone/contenttypes/behaviors/luogo.py:65
+#: design/plone/contenttypes/behaviors/luogo.py:145
 msgid "struttura_responsabile_help"
 msgstr ""
 
-#. Default: "Indica un eventuale sottotitolo/titolo alternativo per questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:46
-msgid "subtitle_help"
+#. Default: "Seleziona la lista delle strutture politiche coinvolte."
+#: design/plone/contenttypes/behaviors/strutture_correlate.py:25
+msgid "strutture_politiche_help"
 msgstr ""
 
 #. Default: "Evento supportato da"
-#: design/plone/contenttypes/behaviors/evento.py:221
+#: design/plone/contenttypes/behaviors/evento.py:146
 msgid "supportato_da"
 msgstr ""
 
-#. Default: "Tassonomia argomenti"
-#: design/plone/contenttypes/behaviors/evento.py:58
-msgid "tassonomia_argomenti"
+#. Default: "Se l'evento è organizzato direttamente dal comune, indicare l'ufficio/ente che supporta l'evento."
+#: design/plone/contenttypes/behaviors/evento.py:153
+msgid "supportato_da_help"
 msgstr ""
 
 #. Default: "Seleziona una lista di argomenti d'interesse per questo contenuto."
-#: design/plone/contenttypes/behaviors/argomenti.py:20
+#: design/plone/contenttypes/behaviors/argomenti.py:21
 msgid "tassonomia_argomenti_help"
 msgstr ""
 
 #. Default: "Tassonomia argomenti"
-#: design/plone/contenttypes/behaviors/argomenti.py:19
+#: design/plone/contenttypes/behaviors/argomenti.py:20
 msgid "tassonomia_argomenti_label"
 msgstr ""
 
 #. Default: "Numero di telefono"
-#: design/plone/contenttypes/interfaces/persona.py:208
+#: design/plone/contenttypes/interfaces/persona.py:76
 msgid "telefono"
 msgstr ""
 
 #. Default: "Contatto telefonico della persona."
-#: design/plone/contenttypes/interfaces/persona.py:209
+#: design/plone/contenttypes/interfaces/persona.py:77
 msgid "telefono_help"
 msgstr ""
 
@@ -1655,8 +1797,28 @@ msgstr ""
 msgid "temi"
 msgstr ""
 
+#. Default: "Tempi e scadenze"
+#: design/plone/contenttypes/interfaces/servizio.py:171
+msgid "tempi_e_scadenze"
+msgstr ""
+
+#. Default: "Descrivere le informazioni dettagliate riguardo eventuali tempi e scadenze di questo servizio."
+#: design/plone/contenttypes/interfaces/servizio.py:173
+msgid "tempi_e_scadenze_help"
+msgstr ""
+
+#. Default: "Tempi e scadenze"
+#: design/plone/contenttypes/interfaces/servizio.py:413
+msgid "tempi_e_scadenze_label"
+msgstr ""
+
+#. Default: "Testata"
+#: design/plone/contenttypes/behaviors/info_testata.py:51
+msgid "testata_fieldset_label"
+msgstr ""
+
 #. Default: "Tipologia documento"
-#: design/plone/contenttypes/interfaces/messaggio.py:54
+#: design/plone/contenttypes/interfaces/messaggio.py:50
 msgid "tipologia_documento"
 msgstr ""
 
@@ -1671,22 +1833,22 @@ msgid "tipologia_notizia_label"
 msgstr ""
 
 #. Default: "Tipologia organizzazione"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:79
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:54
 msgid "tipologia_organizzazione"
 msgstr ""
 
 #. Default: "Specificare la tipologia di organizzazione: politica, amminsitrativa o di altro tipo."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:85
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:57
 msgid "tipologia_organizzazione_help"
 msgstr ""
 
 #. Default: "Tipologia persona"
-#: design/plone/contenttypes/interfaces/persona.py:187
+#: design/plone/contenttypes/interfaces/persona.py:28
 msgid "tipologia_persona"
 msgstr ""
 
 #. Default: "Seleziona la tipologia di persona: politica, amministrativa o di altro tipo."
-#: design/plone/contenttypes/interfaces/persona.py:188
+#: design/plone/contenttypes/interfaces/persona.py:29
 msgid "tipologia_persona_help"
 msgstr ""
 
@@ -1696,22 +1858,22 @@ msgid "titolare"
 msgstr ""
 
 #. Default: "Ufficio responsabile del documento"
-#: design/plone/contenttypes/interfaces/documento.py:37
+#: design/plone/contenttypes/interfaces/documento.py:32
 msgid "ufficio_responsabile"
 msgstr ""
 
 #. Default: "Ufficio responsabile"
-#: design/plone/contenttypes/interfaces/documento_personale.py:71
+#: design/plone/contenttypes/interfaces/documento_personale.py:63
 msgid "ufficio_responsabile_documento_personale"
 msgstr ""
 
-#. Default: "Ufficio resposabile"
-#: design/plone/contenttypes/interfaces/servizio.py:222
+#. Default: "Ufficio responsabile"
+#: design/plone/contenttypes/interfaces/servizio.py:219
 msgid "ufficio_responsabile_erogazione"
 msgstr ""
 
 #. Default: "Seleziona l'ufficio responsabile dell'erogazione di questo servizio."
-#: design/plone/contenttypes/interfaces/servizio.py:223
+#: design/plone/contenttypes/interfaces/servizio.py:220
 msgid "ufficio_responsabile_help"
 msgstr ""
 
@@ -1721,41 +1883,46 @@ msgid "ufficio_riferimento"
 msgstr ""
 
 #. Default: "Ulteriori informazioni"
-#: design/plone/contenttypes/behaviors/additional_help_infos.py:17
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:19
 msgid "ulteriori_informazioni"
 msgstr ""
 
 #. Default: "Ulteriori informazioni non contemplate dai campi precedenti."
-#: design/plone/contenttypes/behaviors/additional_help_infos.py:18
+#: design/plone/contenttypes/behaviors/additional_help_infos.py:20
 msgid "ulteriori_informazioni_help"
 msgstr ""
 
+#. Default: "Unità amministrativa responsabile"
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:28
+msgid "unita_amministrativa_responsabile"
+msgstr ""
+
+#. Default: "Seleziona la lista delle unità amministrative responsabili di questo argomento."
+#: design/plone/contenttypes/interfaces/pagina_argomento.py:38
+msgid "unita_amministrativa_responsabile_help"
+msgstr ""
+
 #. Default: "Informazioni"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:167
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:98
 msgid "unteriori_informazioni"
 msgstr ""
 
-#. Default: "Eventuali contatti di supporto all'utente."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:174
-msgid "uo_box_aiuto_help"
-msgstr ""
-
 #. Default: "Descrizione dei compiti assegnati alla struttura."
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:18
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:19
 msgid "uo_competenze_help"
 msgstr ""
 
 #. Default: "Eventuali informazioni di contatto generiche"
-#: design/plone/contenttypes/interfaces/unita_organizzativa.py:207
+#: design/plone/contenttypes/interfaces/unita_organizzativa.py:116
 msgid "uo_contact_info_description"
 msgstr ""
 
 #. Default: "Vincoli"
-#: design/plone/contenttypes/interfaces/servizio.py:202
+#: design/plone/contenttypes/interfaces/servizio.py:200
 msgid "vincoli"
 msgstr ""
 
 #. Default: "Descrizione degli eventuali vincoli presenti."
-#: design/plone/contenttypes/interfaces/servizio.py:204
+#: design/plone/contenttypes/interfaces/servizio.py:202
 msgid "vincoli_help"
 msgstr ""

--- a/src/design/plone/contenttypes/profiles/default/metadata.xml
+++ b/src/design/plone/contenttypes/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <metadata>
-    <version>1000</version>
+    <version>1001</version>
   <dependencies>
     <dependency>profile-collective.venue:default</dependency>
     <dependency>profile-redturtle.volto:default</dependency>

--- a/src/design/plone/contenttypes/profiles/default/types/Documento_Personale.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Documento_Personale.xml
@@ -47,18 +47,8 @@
     <element value="plone.categorization"/>
     <element value="plone.basic"/>
     <element value="design.plone.contenttypes.behavior.descrizione_estesa" />
+    <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
     <element value="plone.locking" />
-    <!--<element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />-->
-    <!--<element value="plone.leadimage"/>-->
-    <!--<element value="plone.relateditems"/>-->
-    <!--<element value="plone.richtext"/>-->
-    <!--<element value="plone.tableofcontents"/>-->
-    <!--<element value="plone.versionable" />-->
-    <!--<element value="plone.translatable" />-->
-    <!--<element value="plone.nextprevioustoggle" />-->
-    <!--<element value="plone.nextpreviousenabled" />-->
-    <!--<element value="plone.navigationroot" />-->
-    <!--<element value="plone.selectablecontrainstypes" />-->
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Event.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Event.xml
@@ -7,7 +7,6 @@
  </property>
   <property name="behaviors" purge="false">
     <element value="design.plone.contenttypes.behavior.evento"/>
-    <element value="design.plone.contenttypes.behavior.additional_help_infos_evento"/>
     <element value="design.plone.contenttypes.behavior.strutture_correlate"/>
     <element value="design.plone.contenttypes.behavior.luoghi_correlati_evento"/>
     <element value="plone.leadimage"/>

--- a/src/design/plone/contenttypes/profiles/default/types/Event.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Event.xml
@@ -17,7 +17,7 @@
     <element value="plone.eventlocation" remove="True"/>
     <element value="plone.eventattendees" remove="True"/>
     <element value="design.plone.contenttypes.behavior.argomenti" remove="True"/>
-    <element value="design.plone.contenttypes.behavior.additional_help_infos" remove="True"/>
+    <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
     <element value="design.plone.contenttypes.behavior.luoghi_correlati" remove="True"/>
     
 

--- a/src/design/plone/contenttypes/profiles/default/types/Event.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Event.xml
@@ -7,7 +7,6 @@
  </property>
   <property name="behaviors" purge="false">
     <element value="design.plone.contenttypes.behavior.evento"/>
-    <element value="design.plone.contenttypes.behavior.argomenti_evento"/>
     <element value="design.plone.contenttypes.behavior.additional_help_infos_evento"/>
     <element value="design.plone.contenttypes.behavior.strutture_correlate"/>
     <element value="design.plone.contenttypes.behavior.luoghi_correlati_evento"/>
@@ -16,10 +15,8 @@
     <element value="collective.venue.behaviors.ILocation" remove="True"/>
     <element value="plone.eventlocation" remove="True"/>
     <element value="plone.eventattendees" remove="True"/>
-    <element value="design.plone.contenttypes.behavior.argomenti" remove="True"/>
+    <element value="plone.eventcontact" remove="True"/>
+    <element value="design.plone.contenttypes.behavior.argomenti"/>
     <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
-    <element value="design.plone.contenttypes.behavior.luoghi_correlati" remove="True"/>
-    
-
   </property>
 </object>

--- a/src/design/plone/contenttypes/profiles/default/types/Messaggio.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Messaggio.xml
@@ -47,17 +47,7 @@
     <element value="plone.categorization"/>
     <element value="plone.basic"/>
     <element value="plone.locking" />
-    <!--<element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />-->
-    <!--<element value="plone.leadimage"/>-->
-    <!--<element value="plone.relateditems"/>-->
-    <!--<element value="plone.richtext"/>-->
-    <!--<element value="plone.tableofcontents"/>-->
-    <!--<element value="plone.versionable" />-->
-    <!--<element value="plone.translatable" />-->
-    <!--<element value="plone.nextprevioustoggle" />-->
-    <!--<element value="plone.nextpreviousenabled" />-->
-    <!--<element value="plone.navigationroot" />-->
-    <!--<element value="plone.selectablecontrainstypes" />-->
+    <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Pagina_Argomento.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Pagina_Argomento.xml
@@ -50,6 +50,7 @@
     <element value="plone.leadimage" />
     <element value="collective.dexteritytextindexer"/>
     <element value="volto.blocks" />
+    <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Servizio.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Servizio.xml
@@ -48,6 +48,7 @@
     <element value="plone.leadimage"/>
     <element value="plone.relateditems"/>
     <element value="design.plone.contenttypes.behavior.argomenti"/>
+    <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
     <element value="collective.dexteritytextindexer"/>
   </property>
 

--- a/src/design/plone/contenttypes/profiles/default/types/UnitaOrganizzativa.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/UnitaOrganizzativa.xml
@@ -50,6 +50,7 @@
     <element value="plone.relateditems"/>
     <element value="design.plone.contenttypes.behavior.argomenti"/>
     <element value="collective.dexteritytextindexer"/>
+    <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/restapi/services/types/get.py
+++ b/src/design/plone/contenttypes/restapi/services/types/get.py
@@ -10,6 +10,86 @@ from plone import api
 from design.plone.contenttypes import _
 
 
+class FieldsetsMismatchError(Exception):
+    """Exception thrown when we try to reorder fieldsets, but the order list is
+    different from the fieldsets returned from Plone
+    """
+
+
+FIELDSETS_ORDER = {
+    "Document": [
+        "default",
+        "testata",
+        "settings",
+        "categorization",
+        "dates",
+        "ownership",
+        "layout",
+    ],
+    "Event": [
+        "default",
+        "date_evento",
+        "partecipanti",
+        "dove",
+        "costi",
+        "contatti",
+        "informazioni",
+        "correlati",
+        "categorization",
+        "dates",
+        "settings",
+        "layout",
+        "ownership",
+    ],
+    "News Item": [
+        "default",
+        "correlati",
+        "categorization",
+        "dates",
+        "ownership",
+        "settings",
+        "layout",
+    ],
+    "Persona": [
+        "default",
+        "informazioni",
+        "correlati",
+        "categorization",
+        "settings",
+        "ownership",
+        "dates",
+    ],
+    "Servizio": [
+        "default",
+        "a_chi_si_rivolge",
+        "accedi_al_servizio",
+        "cosa_serve",
+        "costi_e_vincoli",
+        "tempi_e_scadenze",
+        "casi_particolari",
+        "contatti",
+        "documenti",
+        "link_utili",
+        "informazioni",
+        "correlati",
+        "categorization",
+        "settings",
+        "ownership",
+        "dates",
+    ],
+    "UnitaOrganizzativa": [
+        "default",
+        "informazioni",
+        "correlati",
+        "settings",
+        "ownership",
+        "dates",
+        "categorization",
+    ],
+    "Venue": ["default", "informazioni", "correlati", "contatti", "categorization"],
+}
+
+
 @implementer(IPublishTraverse)
 class TypesGet(BaseGet):
     def customize_venue_schema(self, result):
@@ -18,22 +98,19 @@ class TypesGet(BaseGet):
             correlati_index = ids.index("correlati")
             contatti_index = ids.index("contatti")
             result["fieldsets"].insert(
-                correlati_index + 1, result["fieldsets"].pop(contatti_index),
+                correlati_index + 1, result["fieldsets"].pop(contatti_index)
             )
         return result
 
     def customize_persona_schema(self, result):
         msgid = _(u"Nome e Cognome", default="Nome e cognome")
-        result["properties"]["title"]["title"] = translate(
-            msgid, context=self.request
-        )
+        result["properties"]["title"]["title"] = translate(msgid, context=self.request)
         if "fieldsets" in result:
             ids = [x["id"] for x in result["fieldsets"]]
             correlati_index = ids.index("correlati")
             categorization_index = ids.index("categorization")
             result["fieldsets"].insert(
-                correlati_index + 1,
-                result["fieldsets"].pop(categorization_index),
+                correlati_index + 1, result["fieldsets"].pop(categorization_index)
             )
         return result
 
@@ -54,9 +131,7 @@ class TypesGet(BaseGet):
             result["fieldsets"][correlati_index]["fields"].remove(
                 "tassonomia_argomenti"
             )
-            result["fieldsets"][correlati_index]["fields"].remove(
-                "luoghi_correlati"
-            )
+            result["fieldsets"][correlati_index]["fields"].remove("luoghi_correlati")
 
             fieldsets_weight = {
                 "default": 0,
@@ -80,38 +155,8 @@ class TypesGet(BaseGet):
         result = super(TypesGet, self).reply()
 
         if "fieldsets" in result:
-            ids = [x["id"] for x in result["fieldsets"]]
-            if "correlati" in ids:
-                #  move correlati before categorization
-                default_index = ids.index("default")
-                correlati_index = ids.index("correlati")
-                result["fieldsets"].insert(
-                    default_index + 1, result["fieldsets"].pop(correlati_index)
-                )
-            if "testata" in ids:
-                #  move testata after default
-                default_index = ids.index("default")
-                testata_index = ids.index("testata")
-                result["fieldsets"].insert(
-                    default_index + 1, result["fieldsets"].pop(testata_index)
-                )
-            if "default" in ids:
-                # move sedi after geolocation
-                idx = ids.index("default")
-                if (
-                    "sedi" in result["fieldsets"][idx]["fields"]
-                    and "geolocation" in result["fieldsets"][idx]["fields"]
-                ):
-                    geo_index = result["fieldsets"][idx]["fields"].index(
-                        "geolocation"
-                    )
-                    sedi_index = result["fieldsets"][idx]["fields"].index(
-                        "sedi"
-                    )
-                    result["fieldsets"][idx]["fields"].insert(
-                        geo_index,
-                        result["fieldsets"][idx]["fields"].pop(sedi_index),
-                    )
+            result["fieldsets"] = self.reorder_fieldsets(original=result["fieldsets"])
+
         if "properties" in result:
             if "country" in result["properties"]:
                 if not result["properties"]["country"].get("default", ""):
@@ -151,13 +196,32 @@ class TypesGet(BaseGet):
                     )
         # be careful: result could be dict or list. If list it will not
         # contains title. And this is ok for us.
-        pt = self.request.PATH_INFO.split("/")[-1]
-        if "title" in result and pt == "Venue":
-            result = self.customize_venue_schema(result)
+        # pt = self.request.PATH_INFO.split("/")[-1]
+        # if "title" in result and pt == "Venue":
+        #     result = self.customize_venue_schema(result)
 
-        if "title" in result and pt == "Persona":
-            result = self.customize_persona_schema(result)
+        # if "title" in result and pt == "Persona":
+        #     result = self.customize_persona_schema(result)
 
-        if "title" in result and pt == "Event":
-            result = self.customize_evento_schema(result)
+        # if "title" in result and pt == "Event":
+        #     result = self.customize_evento_schema(result)
         return result
+
+    def reorder_fieldsets(self, original):
+        pt = self.request.PATH_INFO.split("/")[-1]
+        order = FIELDSETS_ORDER.get(pt, [])
+        if not order:
+            # no match
+            return original
+        if set(order) != set([x["id"] for x in original]):
+            # list mismatch
+            raise FieldsetsMismatchError("Fieldset mismatch for {}".format(pt))
+        new = []
+        for id in order:
+            for fieldset in original:
+                if fieldset["id"] == id:
+                    new.append(fieldset)
+        if not new:
+            # no match
+            new = original
+        return new

--- a/src/design/plone/contenttypes/restapi/services/types/get.py
+++ b/src/design/plone/contenttypes/restapi/services/types/get.py
@@ -92,26 +92,9 @@ FIELDSETS_ORDER = {
 
 @implementer(IPublishTraverse)
 class TypesGet(BaseGet):
-    def customize_venue_schema(self, result):
-        if "fieldsets" in result:
-            ids = [x["id"] for x in result["fieldsets"]]
-            correlati_index = ids.index("correlati")
-            contatti_index = ids.index("contatti")
-            result["fieldsets"].insert(
-                correlati_index + 1, result["fieldsets"].pop(contatti_index)
-            )
-        return result
-
     def customize_persona_schema(self, result):
         msgid = _(u"Nome e Cognome", default="Nome e cognome")
         result["properties"]["title"]["title"] = translate(msgid, context=self.request)
-        if "fieldsets" in result:
-            ids = [x["id"] for x in result["fieldsets"]]
-            correlati_index = ids.index("correlati")
-            categorization_index = ids.index("categorization")
-            result["fieldsets"].insert(
-                correlati_index + 1, result["fieldsets"].pop(categorization_index)
-            )
         return result
 
     def customize_evento_schema(self, result):
@@ -196,12 +179,9 @@ class TypesGet(BaseGet):
                     )
         # be careful: result could be dict or list. If list it will not
         # contains title. And this is ok for us.
-        # pt = self.request.PATH_INFO.split("/")[-1]
-        # if "title" in result and pt == "Venue":
-        #     result = self.customize_venue_schema(result)
-
-        # if "title" in result and pt == "Persona":
-        #     result = self.customize_persona_schema(result)
+        pt = self.request.PATH_INFO.split("/")[-1]
+        if "title" in result and pt == "Persona":
+            result = self.customize_persona_schema(result)
 
         # if "title" in result and pt == "Event":
         #     result = self.customize_evento_schema(result)

--- a/src/design/plone/contenttypes/restapi/services/types/get.py
+++ b/src/design/plone/contenttypes/restapi/services/types/get.py
@@ -97,43 +97,6 @@ class TypesGet(BaseGet):
         result["properties"]["title"]["title"] = translate(msgid, context=self.request)
         return result
 
-    def customize_evento_schema(self, result):
-        result["properties"].pop("contact_email")
-        result["properties"].pop("contact_name")
-        result["properties"].pop("contact_phone")
-        if "fieldsets" in result:
-
-            result["fieldsets"][0]["fields"].remove("contact_email")
-            result["fieldsets"][0]["fields"].remove("contact_name")
-            result["fieldsets"][0]["fields"].remove("contact_phone")
-
-            # Esteso i behavior per farli specifici per evento, ma mette il
-            # campo in due fieldset. Lo togliamo da dove non serve.
-            ids = [x["id"] for x in result["fieldsets"]]
-            correlati_index = ids.index("correlati")
-            result["fieldsets"][correlati_index]["fields"].remove(
-                "tassonomia_argomenti"
-            )
-            result["fieldsets"][correlati_index]["fields"].remove("luoghi_correlati")
-
-            fieldsets_weight = {
-                "default": 0,
-                "date_evento": 1,
-                "partecipanti": 2,
-                "dove": 3,
-                "costi": 4,
-                "contatti": 5,
-                "informazioni": 6,
-                "correlati": 7,
-                "categorization": 8,
-            }
-            # sort against above dictionary. In case of fieldset not in this
-            # dict, apply 100 and sort by title
-            result["fieldsets"].sort(
-                key=lambda x: (fieldsets_weight.get(x["id"], 100), x["title"])
-            )
-        return result
-
     def reply(self):
         result = super(TypesGet, self).reply()
 
@@ -177,14 +140,12 @@ class TypesGet(BaseGet):
                             "geolocation", interface=IGeolocationDefaults
                         )
                     )
+
         # be careful: result could be dict or list. If list it will not
         # contains title. And this is ok for us.
         pt = self.request.PATH_INFO.split("/")[-1]
         if "title" in result and pt == "Persona":
             result = self.customize_persona_schema(result)
-
-        # if "title" in result and pt == "Event":
-        #     result = self.customize_evento_schema(result)
         return result
 
     def reorder_fieldsets(self, original):

--- a/src/design/plone/contenttypes/restapi/services/types/get.py
+++ b/src/design/plone/contenttypes/restapi/services/types/get.py
@@ -86,7 +86,7 @@ FIELDSETS_ORDER = {
         "dates",
         "categorization",
     ],
-    "Venue": ["default", "informazioni", "correlati", "contatti", "categorization"],
+    "Venue": ["default", "informazioni", "contatti", "categorization"],
 }
 
 

--- a/src/design/plone/contenttypes/schema_overrides.py
+++ b/src/design/plone/contenttypes/schema_overrides.py
@@ -23,37 +23,37 @@ class SchemaTweaks(object):
         if self.schema.getName() == "IRelatedItems":
             fieldset = Fieldset(
                 "correlati",
-                label=_("correlati_label", default=u"Correlati"),
+                label=_("correlati_label", default="Contenuti collegati"),
                 fields=["relatedItems"],
             )
-            self.schema._Element__tagged_values[
-                "plone.supermodel.fieldsets"
-            ] = [fieldset]
+            self.schema._Element__tagged_values["plone.supermodel.fieldsets"] = [
+                fieldset
+            ]
         if self.schema.getName() == "IEventBasic":
             fieldset = Fieldset(
                 "date_evento",
                 label=_("date_evento_label", default=u"Date dell'evento"),
                 fields=["start", "end", "whole_day", "open_end", "sync_uid"],
             )
-            self.schema._Element__tagged_values[
-                "plone.supermodel.fieldsets"
-            ] = [fieldset]
+            self.schema._Element__tagged_values["plone.supermodel.fieldsets"] = [
+                fieldset
+            ]
         if self.schema.getName() == "IEventRecurrence":
             fieldset = Fieldset(
                 "date_evento",
                 label=_("date_evento_label", default=u"Date dell'evento"),
                 fields=["recurrence"],
             )
-            self.schema._Element__tagged_values[
-                "plone.supermodel.fieldsets"
-            ] = [fieldset]
+            self.schema._Element__tagged_values["plone.supermodel.fieldsets"] = [
+                fieldset
+            ]
 
         if self.schema.getName() == "IEventContact":
             fieldset_informazioni = Fieldset(
                 "informazioni",
-                label=_("informazioni_label", default=u"Informazioni"),
+                label=_("informazioni_label", default=u"Ulteriori informazioni"),
                 fields=["event_url"],
             )
-            self.schema._Element__tagged_values[
-                "plone.supermodel.fieldsets"
-            ] = [fieldset_informazioni]
+            self.schema._Element__tagged_values["plone.supermodel.fieldsets"] = [
+                fieldset_informazioni
+            ]

--- a/src/design/plone/contenttypes/tests/test_content_types.py
+++ b/src/design/plone/contenttypes/tests/test_content_types.py
@@ -3,6 +3,7 @@
 from design.plone.contenttypes.testing import (
     DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING,
 )
+from design.plone.contenttypes.restapi.services.types.get import FIELDSETS_ORDER
 from plone.app.testing import (
     SITE_OWNER_NAME,
     SITE_OWNER_PASSWORD,
@@ -43,44 +44,53 @@ class TestContentTypes(unittest.TestCase):
     def tearDown(self):
         self.api_session.close()
 
-    def test_persona_correlati_fieldset_order(self):
+    def test_persona_fieldset_order(self):
         response = self.api_session.get("/@types/Persona")
         res = response.json()
 
         ids = [x["id"] for x in res["fieldsets"]]
 
-        self.assertIn("correlati", ids)
-        self.assertEqual(
-            ids,
-            [
-                "default",
-                "correlati",
-                "categorization",
-                "settings",
-                "ownership",
-                "dates",
-            ],
-        )
+        self.assertEqual(ids, FIELDSETS_ORDER["Persona"])
 
-    def test_news_correlati_fieldset_order(self):
+    def test_news_item_fieldset_order(self):
         response = self.api_session.get("/@types/News%20Item")
         res = response.json()
 
         ids = [x["id"] for x in res["fieldsets"]]
 
-        self.assertIn("correlati", ids)
-        self.assertEqual(
-            ids,
-            [
-                "default",
-                "correlati",
-                "categorization",
-                "dates",
-                "ownership",
-                "settings",
-                "layout",
-            ],
-        )
+        self.assertEqual(ids, FIELDSETS_ORDER["News Item"])
+
+    def test_event_fieldset_order(self):
+        response = self.api_session.get("/@types/Event")
+        res = response.json()
+
+        ids = [x["id"] for x in res["fieldsets"]]
+
+        self.assertEqual(ids, FIELDSETS_ORDER["Event"])
+
+    def test_servizio_fieldset_order(self):
+        response = self.api_session.get("/@types/Servizio")
+        res = response.json()
+
+        ids = [x["id"] for x in res["fieldsets"]]
+
+        self.assertEqual(ids, FIELDSETS_ORDER["Servizio"])
+
+    def test_unitaorganizzativa_fieldset_order(self):
+        response = self.api_session.get("/@types/UnitaOrganizzativa")
+        res = response.json()
+
+        ids = [x["id"] for x in res["fieldsets"]]
+
+        self.assertEqual(ids, FIELDSETS_ORDER["UnitaOrganizzativa"])
+
+    def test_venue_fieldset_order(self):
+        response = self.api_session.get("/@types/Venue")
+        res = response.json()
+
+        ids = [x["id"] for x in res["fieldsets"]]
+
+        self.assertEqual(ids, FIELDSETS_ORDER["Venue"])
 
     def test_image_field_description(self):
         response = self.api_session.get("/@types/News%20Item")

--- a/src/design/plone/contenttypes/tests/test_ct_documento_personale.py
+++ b/src/design/plone/contenttypes/tests/test_ct_documento_personale.py
@@ -28,6 +28,7 @@ class TestDocument(unittest.TestCase):
                 "plone.categorization",
                 "plone.basic",
                 "design.plone.contenttypes.behavior.descrizione_estesa",
+                "design.plone.contenttypes.behavior.additional_help_infos",
                 "plone.locking",
             ),
         )

--- a/src/design/plone/contenttypes/tests/test_ct_event.py
+++ b/src/design/plone/contenttypes/tests/test_ct_event.py
@@ -30,7 +30,6 @@ class TestEvent(unittest.TestCase):
             (
                 "plone.eventbasic",
                 "plone.eventrecurrence",
-                "plone.eventcontact",
                 "plone.dublincore",
                 "plone.namefromtitle",
                 "plone.allowdiscussion",
@@ -42,10 +41,10 @@ class TestEvent(unittest.TestCase):
                 "plone.constraintypes",
                 "volto.blocks",
                 "design.plone.contenttypes.behavior.evento",
-                "design.plone.contenttypes.behavior.additional_help_infos_evento",
                 "design.plone.contenttypes.behavior.strutture_correlate",
                 "design.plone.contenttypes.behavior.luoghi_correlati_evento",
                 "plone.leadimage",
+                "design.plone.contenttypes.behavior.argomenti",
                 "design.plone.contenttypes.behavior.additional_help_infos",
             ),
         )

--- a/src/design/plone/contenttypes/tests/test_ct_event.py
+++ b/src/design/plone/contenttypes/tests/test_ct_event.py
@@ -43,10 +43,11 @@ class TestEvent(unittest.TestCase):
                 "volto.blocks",
                 "design.plone.contenttypes.behavior.evento",
                 "design.plone.contenttypes.behavior.argomenti_evento",
-                "design.plone.contenttypes.behavior.additional_help_infos_evento",  # noqa
+                "design.plone.contenttypes.behavior.additional_help_infos_evento",
                 "design.plone.contenttypes.behavior.strutture_correlate",
                 "design.plone.contenttypes.behavior.luoghi_correlati_evento",
                 "plone.leadimage",
+                "design.plone.contenttypes.behavior.additional_help_infos",
             ),
         )
 
@@ -74,9 +75,7 @@ class TestEventApi(unittest.TestCase):
         self.event = api.content.create(
             container=self.portal, type="Event", title="Evento"
         )
-        provideAdapter(
-            SchemaTweaks, (IFormFieldProvider,), name="schema.tweaks",
-        )
+        provideAdapter(SchemaTweaks, (IFormFieldProvider,), name="schema.tweaks")
         transaction.commit()
 
     def tearDown(self):
@@ -103,56 +102,25 @@ class TestEventApi(unittest.TestCase):
         event = self.portal["bar"]
 
         self.assertEqual(
-            sorted(["multimedia", "documenti", "sponsor_evento"]),
-            sorted(event.keys()),
+            sorted(["multimedia", "documenti", "sponsor_evento"]), sorted(event.keys())
         )
 
         self.assertEqual(event["multimedia"].portal_type, "Document")
         self.assertEqual(event["multimedia"].constrain_types_mode, 1)
-        self.assertEqual(
-            event["multimedia"].locally_allowed_types, ("Image", "Link")
-        )
+        self.assertEqual(event["multimedia"].locally_allowed_types, ("Image", "Link"))
 
         self.assertEqual(event["sponsor_evento"].portal_type, "Document")
         self.assertEqual(event["sponsor_evento"].constrain_types_mode, 1)
-        self.assertEqual(
-            event["sponsor_evento"].locally_allowed_types, ("Link",)
-        )
+        self.assertEqual(event["sponsor_evento"].locally_allowed_types, ("Link",))
 
         self.assertEqual(event["documenti"].portal_type, "Document")
         self.assertEqual(event["documenti"].constrain_types_mode, 1)
-        self.assertEqual(
-            event["documenti"].locally_allowed_types, ("File",),
-        )
+        self.assertEqual(event["documenti"].locally_allowed_types, ("File",))
 
-        multimedia_wf = api.content.get_state(obj=event["multimedia"],)
-        sponsor_wf = api.content.get_state(obj=event["sponsor_evento"],)
-        documenti_wf = api.content.get_state(obj=event["documenti"],)
+        multimedia_wf = api.content.get_state(obj=event["multimedia"])
+        sponsor_wf = api.content.get_state(obj=event["sponsor_evento"])
+        documenti_wf = api.content.get_state(obj=event["documenti"])
 
         self.assertEqual(multimedia_wf, "published")
         self.assertEqual(sponsor_wf, "published")
         self.assertEqual(documenti_wf, "published")
-
-    def test_fieldsets(self):
-        response = self.api_session.get("/@types/Event")
-        fieldsets = response.json()["fieldsets"]
-        # can't provide schema.tweaks adapter... let's check if we have all
-        # expected fieldsets...
-        self.assertEqual(
-            [x["id"] for x in fieldsets],
-            [
-                "default",
-                "date_evento",
-                "partecipanti",
-                "dove",
-                "costi",
-                "contatti",
-                "informazioni",
-                "correlati",
-                "categorization",
-                "dates",
-                "layout",
-                "ownership",
-                "settings",
-            ],
-        )

--- a/src/design/plone/contenttypes/tests/test_ct_event.py
+++ b/src/design/plone/contenttypes/tests/test_ct_event.py
@@ -42,7 +42,6 @@ class TestEvent(unittest.TestCase):
                 "plone.constraintypes",
                 "volto.blocks",
                 "design.plone.contenttypes.behavior.evento",
-                "design.plone.contenttypes.behavior.argomenti_evento",
                 "design.plone.contenttypes.behavior.additional_help_infos_evento",
                 "design.plone.contenttypes.behavior.strutture_correlate",
                 "design.plone.contenttypes.behavior.luoghi_correlati_evento",

--- a/src/design/plone/contenttypes/tests/test_ct_luogo.py
+++ b/src/design/plone/contenttypes/tests/test_ct_luogo.py
@@ -81,7 +81,7 @@ class TestLuogoApi(unittest.TestCase):
 
         venue = RelationValue(intids.getId(self.venue))
         self.news.luoghi_correlati = [venue]
-        self.service.sedi_e_luoghi = [venue]
+        self.service.dove_rivolgersi = [venue]
         self.uo.luoghi_correlati = [venue]
         pcatalog = getToolByName(self.portal, "portal_catalog")
         pcatalog.manage_reindexIndex(

--- a/src/design/plone/contenttypes/tests/test_ct_luogo.py
+++ b/src/design/plone/contenttypes/tests/test_ct_luogo.py
@@ -102,11 +102,7 @@ class TestLuogoApi(unittest.TestCase):
 
         response = self.api_session.patch(
             venue.absolute_url(),
-            json={
-                "@type": "Venue",
-                "title": "Foo",
-                "geolocation": {"foo": "bar"},
-            },
+            json={"@type": "Venue", "title": "Foo", "geolocation": {"foo": "bar"}},
         )
         message = response.json()["message"]
 
@@ -150,35 +146,14 @@ class TestLuogoApi(unittest.TestCase):
         )
 
     def test_venue_services(self):
-        response = self.api_session.get(
-            self.venue.absolute_url() + "?fullobjects"
-        )
+        response = self.api_session.get(self.venue.absolute_url() + "?fullobjects")
         self.assertTrue(
-            response.json()["venue_services"][0]["@id"],
-            self.service.absolute_url(),
+            response.json()["venue_services"][0]["@id"], self.service.absolute_url()
         )
 
     def test_venue_news(self):
-        response = self.api_session.get(
-            self.venue.absolute_url() + "?fullobjects"
-        )
+        response = self.api_session.get(self.venue.absolute_url() + "?fullobjects")
 
         self.assertTrue(
             response.json()["related_news"][0]["@id"], self.news.absolute_url()
         )
-
-    # def test_venue_offices(self):
-    # Per ora non gestiamo ma gestiremo nel prossimo futuro
-    #     response = self.api_session.get(
-    #         self.venue.absolute_url() + "?fullobjects"
-    #     )
-    #     self.assertTrue(
-    #         response.json()["venue_offices"][0]["@id"], self.uo.absolute_url()
-    #     )
-
-    def test_venue_fieldsets(self):
-        response = self.api_session.get("/@types/Venue")
-        fieldsets = response.json()["fieldsets"]
-        self.assertEqual(fieldsets[0]["id"], "default")
-        self.assertEqual(fieldsets[1]["id"], "correlati")
-        self.assertEqual(fieldsets[2]["id"], "contatti")

--- a/src/design/plone/contenttypes/tests/test_ct_pagina_argomento.py
+++ b/src/design/plone/contenttypes/tests/test_ct_pagina_argomento.py
@@ -31,5 +31,6 @@ class TestPaginaArgomento(unittest.TestCase):
                 "plone.leadimage",
                 "collective.dexteritytextindexer",
                 "volto.blocks",
+                "design.plone.contenttypes.behavior.additional_help_infos",
             ),
         )

--- a/src/design/plone/contenttypes/tests/test_ct_servizio.py
+++ b/src/design/plone/contenttypes/tests/test_ct_servizio.py
@@ -25,21 +25,12 @@ WIDGET_PROPERTY_CHECKS = {
         "maximumSelectionSize": 1,
         "selectableTypes": ["UnitaOrganizzativa"],
     },
-    "area": {
-        "maximumSelectionSize": 1,
-        "selectableTypes": ["UnitaOrganizzativa"],
-    },
-    "altri_documenti": {
+    "area": {"maximumSelectionSize": 1, "selectableTypes": ["UnitaOrganizzativa"]},
+    "altri_documenti": {"maximumSelectionSize": 10, "selectableTypes": ["Documento"]},
+    "servizi_collegati": {"maximumSelectionSize": 10, "selectableTypes": ["Servizio"]},
+    "dove_rivolgersi": {
         "maximumSelectionSize": 10,
-        "selectableTypes": ["Documento"],
-    },
-    "servizi_collegati": {
-        "maximumSelectionSize": 10,
-        "selectableTypes": ["Servizio"],
-    },
-    "sedi_e_luoghi": {
-        "maximumSelectionSize": 10,
-        "selectableTypes": ["Venue"],
+        "selectableTypes": ["Venue", "UnitaOrganizzativa"],
     },
 }
 
@@ -72,6 +63,7 @@ class TestServizio(unittest.TestCase):
                 "plone.leadimage",
                 "plone.relateditems",
                 "design.plone.contenttypes.behavior.argomenti",
+                "design.plone.contenttypes.behavior.additional_help_infos",
                 "collective.dexteritytextindexer",
             ),
         )
@@ -129,14 +121,14 @@ class TestServizioApi(unittest.TestCase):
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0].UID, servizio.UID())
 
-    def test_descrizione_destinatari_indexed_in_searchabletext(self):
+    def test_a_chi_si_rivolge_indexed_in_searchabletext(self):
 
         #  Servizio is the only ct with this field
         servizio = api.content.create(
             container=self.portal,
             type="Servizio",
             title="Test servizio",
-            descrizione_destinatari=RichTextValue(
+            a_chi_si_rivolge=RichTextValue(
                 raw="destinatari",
                 mimeType="text/html",
                 outputMimeType="text/html",
@@ -229,14 +221,14 @@ class TestServizioApi(unittest.TestCase):
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0].UID, servizio.UID())
 
-    def test_box_aiuto_indexed_in_searchabletext(self):
+    def test_ulteriori_informazioni_indexed_in_searchabletext(self):
 
         #  Servizio is the only ct with this field
         servizio = api.content.create(
             container=self.portal,
             type="Servizio",
             title="Test servizio",
-            box_aiuto=RichTextValue(
+            ulteriori_informazioni=RichTextValue(
                 raw="aiuto",
                 mimeType="text/html",
                 outputMimeType="text/html",

--- a/src/design/plone/contenttypes/tests/test_ct_servizio.py
+++ b/src/design/plone/contenttypes/tests/test_ct_servizio.py
@@ -34,8 +34,6 @@ WIDGET_PROPERTY_CHECKS = {
     },
 }
 
-FIELDS_IN_CORRELATI_TAB = ["servizi_collegati", "altri_documenti"]
-
 
 class TestServizio(unittest.TestCase):
     layer = DESIGN_PLONE_CONTENTTYPES_INTEGRATION_TESTING
@@ -98,14 +96,6 @@ class TestServizioApi(unittest.TestCase):
                 == WIDGET_PROPERTY_CHECKS[field]
             )
             self.assertTrue(properties[field]["type"] == "array")
-
-    def test_related_widgets_are_in_related_tab(self):
-        response = self.api_session.get("/@types/Servizio")
-        res = response.json()
-        for fieldset in res["fieldsets"]:
-            if fieldset["id"] == "correlati":
-                for field in FIELDS_IN_CORRELATI_TAB:
-                    self.assertTrue(field in fieldset["fields"])
 
     def test_sottotitolo_indexed_in_searchabletext(self):
         #  Servizio is the only ct with this field

--- a/src/design/plone/contenttypes/tests/test_ct_unita_organizzativa.py
+++ b/src/design/plone/contenttypes/tests/test_ct_unita_organizzativa.py
@@ -99,6 +99,7 @@ class TestUO(unittest.TestCase):
                 "plone.relateditems",
                 "design.plone.contenttypes.behavior.argomenti",
                 "collective.dexteritytextindexer",
+                "design.plone.contenttypes.behavior.additional_help_infos",
             ),
         )
 

--- a/src/design/plone/contenttypes/upgrades.py
+++ b/src/design/plone/contenttypes/upgrades.py
@@ -38,6 +38,7 @@ def to_1001(context):
     to_remove = [
         "design.plone.contenttypes.behavior.luoghi_correlati",
         "design.plone.contenttypes.behavior.argomenti_evento",
+        "design.plone.contenttypes.behavior.additional_help_infos",
     ]
     portal_types["Event"].behaviors = tuple(
         [x for x in behaviors if x not in to_remove]

--- a/src/design/plone/contenttypes/upgrades.py
+++ b/src/design/plone/contenttypes/upgrades.py
@@ -31,6 +31,18 @@ def update_controlpanel(context):
 def to_1001(context):
 
     update_types(context)
+
+    # cleanup event behaviors
+    portal_types = api.portal.get_tool(name="portal_types")
+    behaviors = portal_types["Event"].behaviors
+    to_remove = [
+        "design.plone.contenttypes.behavior.luoghi_correlati",
+        "design.plone.contenttypes.behavior.argomenti_evento",
+    ]
+    portal_types["Event"].behaviors = tuple(
+        [x for x in behaviors if x not in to_remove]
+    )
+
     pc = api.portal.get_tool(name="portal_catalog")
     brains = pc()
     mapping = {

--- a/src/design/plone/contenttypes/upgrades.py
+++ b/src/design/plone/contenttypes/upgrades.py
@@ -1,55 +1,58 @@
 # -*- coding: utf-8 -*-
 from plone import api
 
+import logging
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_PROFILE = "profile-design.plone.contenttypes:default"
-
-
-# def import_registry(registry_id, dependencies=False):
-#     setup_tool = api.portal.get_tool("portal_setup")
-#     setup_tool.runImportStepFromProfile(
-#         DEFAULT_PROFILE, registry_id, run_dependencies=dependencies
-#     )
-
-
-def import_types_registry(context):
-    "Import types registry configuration"
-    import_registry("typeinfo")
 
 
 def update_profile(context, profile):
     context.runImportStepFromProfile(DEFAULT_PROFILE, profile)
 
 
-def add_indexes_to_catalog(index_to_add, indextype):
-    pc = api.portal.get_tool("portal_catalog")
-    indexes = pc.indexes()
-    added = 0
-
-    for index in index_to_add:
-        if index not in indexes:
-            pc.addIndex(name=index, type=indextype)
-            added = 1
-
-    if added:
-        pc.refreshCatalog()
+def update_types(context):
+    update_profile(context, "typeinfo")
 
 
-def upgrade_rolemap(context):
+def update_rolemap(context):
     update_profile(context, "rolemap")
 
 
-def add_index_to_search_dashboard(context):
-    add_indexes_to_catalog([], "KeywordIndex")
-
-
-def import_portlets(context):
-    update_profile(context, "portlets")
-
-
-def import_registry(context):
+def update_registry(context):
     update_profile(context, "plone.app.registry")
 
 
-def import_controlpanel(context):
+def update_controlpanel(context):
     update_profile(context, "controlpanel")
+
+
+def to_1001(context):
+
+    update_types(context)
+    pc = api.portal.get_tool(name="portal_catalog")
+    brains = pc()
+    mapping = {
+        "descrizione_destinatari": "a_chi_si_rivolge",
+        "canale_fisico": "dove_rivolgersi_extra",
+        "canale_fisico_prenotazione": "prenota_appuntamento",
+        "fasi_scadenze": "tempi_e_scadenze",
+        "sedi_e_luoghi": "dove_rivolgersi",
+        "box_aiuto": "ulteriori_informazioni",
+    }
+    tot = len(brains)
+    logger.info("Trovati {} elementi da sistemare.".format(tot))
+    # remap fields
+    for brain in brains:
+        item = brain.getObject()
+        for old, new in mapping.items():
+            value = getattr(item, old, None)
+            if value:
+                setattr(item, new, value)
+                setattr(item, old, None)
+                logger.info(
+                    "- {url}: {old} -> {new}".format(
+                        url=brain.getURL(), old=old, new=new
+                    )
+                )

--- a/src/design/plone/contenttypes/upgrades.py
+++ b/src/design/plone/contenttypes/upgrades.py
@@ -38,7 +38,7 @@ def to_1001(context):
     to_remove = [
         "design.plone.contenttypes.behavior.luoghi_correlati",
         "design.plone.contenttypes.behavior.argomenti_evento",
-        "design.plone.contenttypes.behavior.additional_help_infos",
+        "design.plone.contenttypes.behavior.additional_help_infos_event",
     ]
     portal_types["Event"].behaviors = tuple(
         [x for x in behaviors if x not in to_remove]

--- a/src/design/plone/contenttypes/upgrades.zcml
+++ b/src/design/plone/contenttypes/upgrades.zcml
@@ -2,5 +2,12 @@
   xmlns="http://namespaces.zope.org/zope"
   xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
-
+  <genericsetup:upgradeStep
+    source="1000"
+    destination="1001"
+    title="Upgrade to 1001"
+    description=""
+    profile="design.plone.contenttypes:default"
+    handler=".upgrades.to_1001"
+    />
 </configure>

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -13,7 +13,7 @@ flake8 = 3.3.0
 pyflakes = 1.5.0
 pycodestyle = 2.3.1
 plone.restapi = 
-
+plone.schema = 1.2.1
 
 # Added by buildout at 2020-05-05 11:55:23.962087
 collective.folderishtypes = 3.0.0


### PR DESCRIPTION
Dopo le segnalazioni sui campi del servizio, ho cambiato un po' di campi.
In soldoni:

- Nel servizio rinominati alcuni campi con le nuove indicazioni fornite
- Rimossi tutti i campi "box_aiuto" perché avevano un nome che non voleva dire niente, e adesso a chi serve, basta usare la behavior "design.plone.contenttypes.behavior.additional_help_infos"
- Ridefinita la politica di ordinamento dei tab: ora è gestita da una lista statica: è più facile da sistemare
- Pulizia nella rotta che torna le info dei ct
- Upgrade-step per sanare i campi nei contenuti già creati