### PR TITLE
date nei correlati

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-2)
   - [Servizio](#servizio)
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-3)
-  - [Unità Organizzativa](#unit%C3%A0-organizzativa)
+  - [Unità Organizzativa](#unità-organizzativa)
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-4)
 - [Gestione vocabolari](#gestione-vocabolari)
+- [Endpoint restapi](#endpoint-restapi)
+  - [Customizzazione dati relation field](#customizzazione-dati-relation-field)
 - [Installazione](#installazione)
 - [Traduzioni](#traduzioni)
 - [Contribuisci](#contribuisci)
@@ -269,6 +271,14 @@ I vocabolari personalizzabili sono i seguenti:
 
 - Tipologie notizia
 - Tipologie unità organizzativa
+
+# Endpoint restapi
+
+## Customizzazione dati relation field
+
+C'è una customizzazione dei dati ritornati dal serializer per i relation field (correlati)
+per ritornare oltre alle informazioni standard, anche la data di pubblicazione e l'inizio e fine evento.
+
 
 # Installazione
 

--- a/src/design/plone/contenttypes/restapi/serializers/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/serializers/configure.zcml
@@ -6,6 +6,6 @@
     <adapter factory=".related_news_serializer.ServizioSerializer" />
     <adapter factory=".unita_organizzativa.UOSerializer" />
     <adapter factory=".venue.VenueSerializer" />
-
+    <adapter factory=".relationfield.RelationListFieldSerializer" />
 
 </configure>

--- a/src/design/plone/contenttypes/restapi/serializers/relationfield.py
+++ b/src/design/plone/contenttypes/restapi/serializers/relationfield.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from design.plone.contenttypes.interfaces import IDesignPloneContenttypesLayer
+from plone.dexterity.interfaces import IDexterityContent
+from plone.restapi.interfaces import IFieldSerializer
+from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.serializer.relationfield import (
+    RelationListFieldSerializer as DefaultRelationListFieldSerializer,
+)
+from z3c.relationfield.interfaces import IRelationList
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.globalrequest import getRequest
+from zope.interface import implementer
+
+
+@adapter(IRelationList, IDexterityContent, IDesignPloneContenttypesLayer)
+@implementer(IFieldSerializer)
+class RelationListFieldSerializer(DefaultRelationListFieldSerializer):
+    def __call__(self):
+        data = []
+        for value in self.get_value():
+            content = value.to_object
+            if content:
+                summary = getMultiAdapter(
+                    (content, getRequest()), ISerializeToJsonSummary
+                )()
+                if content.effective().Date() != "1969/12/31":
+                    summary["effective"] = json_compatible(content.effective())
+                else:
+                    summary["effective"] = None
+                if content.portal_type == "Event":
+                    summary["start"] = json_compatible(
+                        getattr(content, "start", "")
+                    )
+                    summary["end"] = json_compatible(
+                        getattr(content, "end", "")
+                    )
+                data.append(json_compatible(summary))
+        return data

--- a/src/design/plone/contenttypes/tests/test_relateditems_with_dates.py
+++ b/src/design/plone/contenttypes/tests/test_relateditems_with_dates.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+from DateTime import DateTime
+from datetime import datetime
+from design.plone.contenttypes.testing import (
+    DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING,
+)
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.restapi.testing import RelativeSession
+from transaction import commit
+from z3c.relationfield import RelationValue
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+
+
+import unittest
+
+
+class VocabulariesControlpanelTest(unittest.TestCase):
+
+    layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({"Accept": "application/json"})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        published_news = api.content.create(
+            container=self.portal, type="News Item", title="Published news"
+        )
+        published_news.setEffectiveDate(DateTime())
+        api.content.transition(obj=published_news, transition="publish")
+
+        private_news = api.content.create(
+            container=self.portal, type="News Item", title="Private news"
+        )
+
+        event = api.content.create(
+            container=self.portal,
+            type="Event",
+            title="Event",
+            start=datetime.now(),
+            end=datetime.now(),
+        )
+
+        intids = getUtility(IIntIds)
+        self.page = api.content.create(
+            container=self.portal,
+            type="Document",
+            title="Page",
+            relatedItems=[
+                RelationValue(intids.getId(published_news)),
+                RelationValue(intids.getId(private_news)),
+                RelationValue(intids.getId(event)),
+            ],
+        )
+        commit()
+
+    def tearDown(self):
+        self.api_session.close()
+
+    def test_api_do_not_return_effective_on_private_items(self):
+        response = self.api_session.get(self.page.absolute_url())
+
+        result = response.json()
+        relatedItems = result.get("relatedItems", [])
+        self.assertEqual(len(relatedItems), 3)
+
+        # published news
+        self.assertIn("effective", relatedItems[0])
+        self.assertIsNotNone(relatedItems[0]["effective"])
+
+        # other contents
+        self.assertIn("effective", relatedItems[1])
+        self.assertIsNone(relatedItems[1]["effective"])
+        self.assertIn("effective", relatedItems[2])
+        self.assertIsNone(relatedItems[2]["effective"])
+
+    def test_api_do_return_start_end_on_events(self):
+        response = self.api_session.get(self.page.absolute_url())
+
+        result = response.json()
+        relatedItems = result.get("relatedItems", [])
+        self.assertEqual(len(relatedItems), 3)
+
+        # news
+        self.assertNotIn("start", relatedItems[0])
+        self.assertNotIn("end", relatedItems[0])
+        self.assertNotIn("start", relatedItems[1])
+        self.assertNotIn("end", relatedItems[1])
+
+        # event
+        self.assertIn("start", relatedItems[2])
+        self.assertIn("end", relatedItems[2])


### PR DESCRIPTION
Con questa modifica, l'endpoint ritorna informazioni extra per i vari contenuti correlati dei ct:

- effective: la data di pubblicazione
- start, end: data di inizio e fine evento