### PR TITLE
Us 13953 amministrazione trasparente

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -132,6 +132,8 @@ scripts =
 [versions]
 # Don't use a released version of design.plone.contenttypes
 design.plone.contenttypes =
+plone.namedfile = 5.4.0
+importlib-metadata = 1.0.0
 
 [sources]
 redturtle.volto = git https://github.com/RedTurtle/redturtle.volto.git pushurl=git@github.com:RedTurtle/redturtle.volto.git

--- a/src/design/plone/contenttypes/behaviors/configure.zcml
+++ b/src/design/plone/contenttypes/behaviors/configure.zcml
@@ -229,4 +229,14 @@
       marker=".multi_file.IMultiFile"
       />
 
+    <plone:behavior
+      title="Trasparenza"
+      name="design.plone.contenttypes.behavior.trasparenza"
+      description="Campi aggiuntivi per la sezione amministrazione trasparente."
+      provides=".trasparenza.ITrasparenza"
+      factory=".trasparenza.Trasparenza"
+      marker=".trasparenza.ITrasparenza"
+      />
+
+
 </configure>

--- a/src/design/plone/contenttypes/behaviors/trasparenza.py
+++ b/src/design/plone/contenttypes/behaviors/trasparenza.py
@@ -20,7 +20,7 @@ class ITrasparenza(model.Schema):
     Behavior conenene i campi per la sezione amministrazione trasparente
     """
 
-    modalita_avvio = schema.TextLine(
+    modalita_avvio = RichText(
         title=_(u"modalita_avvio_label", default=u"Modalita di avvio"),
         description=_(
             u"modalita_avvio_help",
@@ -148,6 +148,17 @@ class ITrasparenza(model.Schema):
             default="Organo competente del provvedimento finale.",  # noqa
         ),
     )
+    modalita_richiesta_informazioni = RichText(
+        title=_(
+            u"modalita_richiesta_informazioni_label",
+            default=u"Modalità per richiedere informazioni",
+        ),
+        required=False,
+        description=_(
+            "modalita_richiesta_informazioni_help",
+            default="Indicare le modalità per richiedere informazioni riguardo a questo procedimento.",  # noqa
+        ),
+    )
     procedura_online = schema.TextLine(
         title=_(
             u"procedura_online_label",
@@ -199,7 +210,7 @@ class ITrasparenza(model.Schema):
         ),
         required=False,
     )
-    strumenti_tutela = schema.TextLine(
+    strumenti_tutela = RichText(
         title=_(u"strumenti_tutela_label", default=u"Strumenti di tutela"),
         description=_(
             u"strumenti_tutela_help",
@@ -276,6 +287,7 @@ class ITrasparenza(model.Schema):
             "responsabile_procedimento",
             "dirigente",
             "organo_competente_provvedimento_finale",
+            "modalita_richiesta_informazioni",
             "procedura_online",
             "altre_modalita_invio",
             "atti_documenti_corredo",

--- a/src/design/plone/contenttypes/behaviors/trasparenza.py
+++ b/src/design/plone/contenttypes/behaviors/trasparenza.py
@@ -1,0 +1,299 @@
+# -*- coding: utf-8 -*-
+from design.plone.contenttypes import _
+from plone.app.textfield import RichText
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.dexterity.interfaces import IDexterityContent
+from plone.supermodel import model
+from zope import schema
+from plone.namedfile import field
+from zope.component import adapter
+from zope.interface import provider, implementer
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
+from plone.app.z3cform.widget import RelatedItemsFieldWidget
+from plone.autoform import directives as form
+
+
+@provider(IFormFieldProvider)
+class ITrasparenza(model.Schema):
+    """
+    Behavior conenene i campi per la sezione amministrazione trasparente
+    """
+
+    modalita_avvio = schema.TextLine(
+        title=_(u"modalita_avvio_label", default=u"Modalita di avvio"),
+        description=_(
+            u"modalita_avvio_help",
+            default=u"Indicare la modalità di avvio del procedimento.",
+        ),
+        required=False,
+    )
+    descrizione = RichText(
+        title=_(
+            u"descrizione_label", default=u"Descrizione del procedimento",
+        ),
+        required=False,
+        description=_(
+            "descrizione_help",
+            default="Inserisci eventuale testo descrittivo del procedimento.",  # noqa
+        ),
+    )
+    soggetti_esterni = RichText(
+        title=_(
+            u"soggetti_eserni_label",
+            default=u"Soggetti esterni, nonché, strutture interne coinvolte nel procedimento",
+        ),
+        required=False,
+        description=_(
+            "soggetti_eserni_help",
+            default="Inserisci eventuali soggetti esterni, nonché, strutture interne coinvolte nel procedimento.",  # noqa
+        ),
+    )
+    file_correlato = field.NamedBlobFile(
+        title=_("file_correlato_label", default="File correlato"),
+        description=_(
+            "file_correlato_help",
+            default="Inserisci il file correlato di questo pocedimento.",
+        ),
+        required=True,
+    )
+
+    decorrenza_termine = RichText(
+        title=_(
+            u"decorrenza_termini_label",
+            default=u"Decorrenza termine del procedimento",
+        ),
+        required=False,
+        description=_(
+            "decorrenza_termini_help",
+            default="Inserisci la decorrenza termine del procedimento.",  # noqa
+        ),
+    )
+    fine_termine = RichText(
+        title=_(
+            u"fine_termine_label", default=u"Fine termine del procedimento",
+        ),
+        required=False,
+        description=_(
+            "fine_termine_help",
+            default="Inserisci la fine termine del procedimento.",  # noqa
+        ),
+    )
+    tempo_medio = RichText(
+        title=_(
+            u"tempo_medio_label", default=u"Tempo medio del procedimento",
+        ),
+        required=False,
+        description=_(
+            "tempo_medio_help",
+            default="Inserisci il tempo medio del procedimento.",  # noqa
+        ),
+    )
+    silenzio_assenso = schema.Bool(
+        title=_(
+            u"silenzio_assenso_label",
+            default=u"Silenzio assenso/Dichiarazione dell'interessato sostitutiva del provvedimento finale",  # noqa
+        ),
+        default=False,
+        required=False,
+        description=_(
+            "silenzio_assenso_help",
+            default="Indicare se il procedimento prevede il silenzio assenso o la dichiarazione dell'interessato sostitutiva del provvedimento finale.",  # noqa
+        ),
+    )
+    provvedimento_finale = RichText(
+        title=_(
+            u"provvedimento_finale_label",
+            default=u"Provvedimento del procedimento",
+        ),
+        required=False,
+        description=_(
+            "provvedimento_finale_help",
+            default="Eventuale provvedimento finale del procedimento.",  # noqa
+        ),
+    )
+    responsabile_procedimento = RelationList(
+        title=_(
+            "responsabile_procedimento",
+            default=u"Responsabile del procedimento",
+        ),
+        description=_(
+            "responsabile_procedimento_help",
+            default="Indicare il responsabile del procedimento.",
+        ),
+        value_type=RelationChoice(
+            title=_(u"Responsabile procedimento"),
+            vocabulary="plone.app.vocabularies.Catalog",
+        ),
+        required=False,
+        default=[],
+    )
+    dirigente = RelationList(
+        title=_("dirigente", default=u"Dirigente",),
+        description=_("dirigente_help", default="Indicare il dirigente.",),
+        value_type=RelationChoice(
+            title=_(u"Dirigente"), vocabulary="plone.app.vocabularies.Catalog",
+        ),
+        required=False,
+        default=[],
+    )
+    organo_competente_provvedimento_finale = RichText(
+        title=_(
+            u"organo_competente_provvedimento_finale_label",
+            default=u"Organo competente del provvedimento finale",
+        ),
+        required=False,
+        description=_(
+            "organo_competente_provvedimento_finale_help",
+            default="Organo competente del provvedimento finale.",  # noqa
+        ),
+    )
+    procedura_online = schema.TextLine(
+        title=_(
+            u"procedura_online_label",
+            default=u"Procedura informatizzata online",
+        ),
+        description=_(
+            u"procedura_online_help",
+            default=u"Indicare, se la procedura è informatizzata online, il riferimento.",  # noqa
+        ),
+        required=False,
+    )
+    altre_modalita_invio = RichText(
+        title=_(
+            u"altre_modalita_invio_label", default=u"Altre modalità di invio",
+        ),
+        description=_(
+            u"altre_modalita_invio_help",
+            default=u"Indicare, se esistono, altre modalità di invio.",  # noqa
+        ),
+        required=False,
+    )
+    atti_documenti_corredo = RichText(
+        title=_(
+            u"atti_documenti_corredo_label",
+            default=u"Atti e documenti a corredo dell'istanza",
+        ),
+        description=_(
+            u"atti_documenti_corredo_help",
+            default=u"Indicare, se la esistono, atti e documenti a corredo dell'istanza.",  # noqa
+        ),
+        required=False,
+    )
+    reperimento_modulistica = RichText(
+        title=_(
+            u"reperimento_modulistica_label",
+            default=u"Dove reperire la modulistica",
+        ),
+        description=_(
+            u"reperimento_modulistica_help",
+            default=u"Indicare dove è possibile reperre la modulistica per il procedimento.",  # noqa
+        ),
+        required=False,
+    )
+    pagamenti = RichText(
+        title=_(u"pagamenti_label", default=u"Pagamenti previsti e modalità",),
+        description=_(
+            u"pagamenti_help",
+            default=u"Indicare le informazioni riguardanti i pagamenti previsti e modalità di pagamento.",  # noqa
+        ),
+        required=False,
+    )
+    strumenti_tutela = schema.TextLine(
+        title=_(u"strumenti_tutela_label", default=u"Strumenti di tutela"),
+        description=_(
+            u"strumenti_tutela_help",
+            default=u"Indicare gli eventuali strumenti di tutela.",
+        ),
+        required=False,
+    )
+    # rt o collegamento a persona? esiste sempre?
+    titolare_potere_sostitutivo = RichText(
+        title=_(
+            u"titolare_potere_sostitutivo_label",
+            default=u"Titolare del potere sostitutivo",
+        ),
+        required=False,
+        description=_(
+            "titolare_potere_sostitutivo_help",
+            default="Eventuale titolare del potere sostitutivo.",  # noqa
+        ),
+    )
+    customer_satisfaction = RichText(
+        title=_(
+            u"customer_satisfaction_label",
+            default=u"Risultati indagini di customer satisfaction",
+        ),
+        required=False,
+        description=_(
+            "customer_satisfaction_help",
+            default="Risultati indagini di customer satisfaction.",  # noqa
+        ),
+    )
+    riferimenti_normativi = RichText(
+        title=_(
+            u"riferimenti_normativi_label", default=u"Riferimenti normativi",
+        ),
+        required=False,
+        description=_(
+            "riferimenti_normativi_help",
+            default="Indicare eventuali riferimenti normativi.",  # noqa
+        ),
+    )
+
+    form.widget(
+        "responsabile_procedimento",
+        RelatedItemsFieldWidget,
+        vocabulary="plone.app.vocabularies.Catalog",
+        pattern_options={
+            "maximumSelectionSize": 10,
+            "selectableTypes": ["Persona"],
+        },
+    )
+    form.widget(
+        "dirigente",
+        RelatedItemsFieldWidget,
+        vocabulary="plone.app.vocabularies.Catalog",
+        pattern_options={
+            "maximumSelectionSize": 10,
+            "selectableTypes": ["Persona"],
+        },
+    )
+
+    model.fieldset(
+        "trasparenza",
+        label=_("trasparenza_fieldset_label", default=u"Trasparenza"),
+        fields=[
+            "modalita_avvio",
+            "descrizione",
+            "soggetti_esterni",
+            "decorrenza_termine",
+            "fine_termine",
+            "tempo_medio",
+            "file_correlato",
+            "silenzio_assenso",
+            "provvedimento_finale",
+            "responsabile_procedimento",
+            "dirigente",
+            "organo_competente_provvedimento_finale",
+            "procedura_online",
+            "altre_modalita_invio",
+            "atti_documenti_corredo",
+            "reperimento_modulistica",
+            "pagamenti",
+            "strumenti_tutela",
+            "titolare_potere_sostitutivo",
+            "customer_satisfaction",
+            "riferimenti_normativi",
+        ],
+    )
+
+
+@implementer(ITrasparenza)
+@adapter(IDexterityContent)
+class Trasparenza(object):
+    """
+    """
+
+    def __init__(self, context):
+        self.context = context

--- a/src/design/plone/contenttypes/behaviors/trasparenza.py
+++ b/src/design/plone/contenttypes/behaviors/trasparenza.py
@@ -55,7 +55,7 @@ class ITrasparenza(model.Schema):
             "file_correlato_help",
             default="Inserisci il file correlato di questo pocedimento.",
         ),
-        required=True,
+        required=False,
     )
 
     decorrenza_termine = RichText(

--- a/src/design/plone/contenttypes/browser/configure.zcml
+++ b/src/design/plone/contenttypes/browser/configure.zcml
@@ -10,7 +10,12 @@
       directory="overrides"
       layer="design.plone.contenttypes.interfaces.IDesignPloneContenttypesLayer"
       />
-
+   <browser:page
+      for="*"
+      name="trasparenza_view"
+      permission="zope2.View"
+      class=".trasparenza.TrasparenzaView"
+      />
   <configure package="plone.app.dexterity.browser">
     <browser:page
         for="design.plone.contenttypes.interfaces.cartella_modulistica.ICartellaModulistica"

--- a/src/design/plone/contenttypes/browser/configure.zcml
+++ b/src/design/plone/contenttypes/browser/configure.zcml
@@ -16,6 +16,12 @@
       permission="zope2.View"
       class=".trasparenza.TrasparenzaView"
       />
+   <browser:page
+      for="*"
+      name="dettagli_procedimenti_view"
+      permission="zope2.View"
+      class=".trasparenza.DettagliProcedimentiView"
+      />
   <configure package="plone.app.dexterity.browser">
     <browser:page
         for="design.plone.contenttypes.interfaces.cartella_modulistica.ICartellaModulistica"

--- a/src/design/plone/contenttypes/browser/trasparenza.py
+++ b/src/design/plone/contenttypes/browser/trasparenza.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from Products.Five.browser import BrowserView
 
 

--- a/src/design/plone/contenttypes/browser/trasparenza.py
+++ b/src/design/plone/contenttypes/browser/trasparenza.py
@@ -11,3 +11,15 @@ class TrasparenzaView(BrowserView):
 
     def __call__(self):
         return
+
+
+class DettagliProcedimentiView(BrowserView):
+    """
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self):
+        return

--- a/src/design/plone/contenttypes/browser/trasparenza.py
+++ b/src/design/plone/contenttypes/browser/trasparenza.py
@@ -1,0 +1,13 @@
+from Products.Five.browser import BrowserView
+
+
+class TrasparenzaView(BrowserView):
+    """
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self):
+        return

--- a/src/design/plone/contenttypes/profiles/default/types/Document.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Document.xml
@@ -7,5 +7,6 @@
    <property name="view_methods">
     <element value="document_view" />
     <element value="trasparenza_view"/>
+    <element value="dettagli_procedimenti_view"/>
   </property>
 </object>

--- a/src/design/plone/contenttypes/profiles/default/types/Document.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Document.xml
@@ -4,5 +4,8 @@
  <property name="behaviors" purge="False">
   <element value="design.plone.contenttypes.behavior.info_testata"/>
  </property>
- 
+   <property name="view_methods">
+    <element value="document_view" />
+    <element value="trasparenza_view"/>
+  </property>
 </object>

--- a/src/design/plone/contenttypes/profiles/default/types/Servizio.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Servizio.xml
@@ -49,6 +49,7 @@
     <element value="design.plone.contenttypes.behavior.argomenti"/>
     <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
     <element value="collective.dexteritytextindexer"/>
+    <element value="design.plone.contenttypes.behavior.trasparenza"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/restapi/services/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/services/configure.zcml
@@ -5,7 +5,8 @@
     <include package=".modulistica_items" />
     <include package=".types" />
     <include package=".scadenziario" />
-    
+    <include package=".trasparenza" />
+
     <adapter
         factory=".controlpanel.VocabulariesControlpanel"
         name="design-plone-vocabularies" />

--- a/src/design/plone/contenttypes/restapi/services/trasparenza/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/services/trasparenza/configure.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+
+  <plone:service
+    method="GET"
+    name="@trasparenza"
+    for="zope.interface.Interface"
+    factory=".get.TrasparenzaService"
+    permission="zope2.View"
+    />
+
+</configure>

--- a/src/design/plone/contenttypes/restapi/services/trasparenza/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/services/trasparenza/configure.zcml
@@ -11,4 +11,14 @@
     permission="zope2.View"
     />
 
+  <plone:service
+    method="GET"
+    name="@trasparenza-items"
+    for="zope.interface.Interface"
+    factory=".get.TrasparenzaItemsGet"
+    permission="zope2.View"
+    />
+
+  <adapter factory=".get.TrasparenzaItems" name="trasparenza-items"/>
+
 </configure>

--- a/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
+++ b/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
@@ -64,6 +64,9 @@ class TrasparenzaItems(object):
         self.request = request
 
     def __call__(self, expand=False):
+        if "amministrazione-trasparente" not in self.context.absolute_url():
+            return {}
+
         result = {
             "trasparenza-items": {
                 "@id": "{}/@trasparenza-items".format(
@@ -73,9 +76,6 @@ class TrasparenzaItems(object):
         }
         if not expand:
             return result
-        import pdb
-
-        pdb.set_trace()
         data = self.get_trasparenza_data()
         if data:
             result["trasparenza-items"] = {"items": data}

--- a/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
+++ b/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
@@ -1,0 +1,44 @@
+from plone import api
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import getMultiAdapter
+from zope.globalrequest import getRequest
+from plone.restapi.services import Service
+
+TRASPARENZA_FIELDS = [
+    "modalita_avvio",
+    "descrizione",
+    "soggetti_esterni",
+    "decorrenza_termine",
+    "dove_rivolgersi",
+    "dove_rivolgersi_extra",
+    "fine_termine",
+    "silenzio_assenso",
+    "provvedimento_finale",
+    "organo_competente_provvedimento_finale",
+    "procedura_online",
+    "altre_modalita_invio",
+    "atti_documenti_corredo",
+    "reperimento_modulistica",
+    "pagamenti",
+    "strumenti_tutela",
+    "titolare_potere_sostitutivo",
+    "customer_satisfaction",
+    "riferimenti_normativi",
+    "tempo medio",
+    "file_correlato",
+    "responsabile_procedimento",
+    "dirigente",
+]
+
+
+class TrasparenzaService(Service):
+    def reply(self):
+        catalog = api.portal.get_tool("portal_catalog")
+        brains = catalog(**{"UID": self.request.uid})[0]
+        obj = getMultiAdapter(
+            (brains.getObject(), getRequest()), ISerializeToJson
+        )()
+        result = {}
+        for field in TRASPARENZA_FIELDS:
+            result[field] = obj.get(field)
+        return result

--- a/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
+++ b/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
@@ -96,7 +96,7 @@ class TrasparenzaItems(object):
                     children = [
                         x
                         for x in self.get_trasparenza_data(context=child)
-                        if x.get("@type", "") in ["Document",]
+                        if x.get("@type", "") in ["Document", ]
                     ]
                     if children:
                         data["items"] = children

--- a/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
+++ b/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
@@ -1,18 +1,15 @@
+# -*- coding: utf-8 -*-
 from plone import api
 from plone.restapi.interfaces import ISerializeToJson
 from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
-from plone.dexterity.utils import iterSchemata
 from plone.restapi.interfaces import IExpandableElement
-from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJsonSummary
-from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from zope.component import adapter
 from zope.component import queryMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
-from zope.schema import getFields
 from Products.CMFCore.interfaces import IFolderish
 
 
@@ -97,7 +94,7 @@ class TrasparenzaItems(object):
                     children = [
                         x
                         for x in self.get_trasparenza_data(context=child)
-                        if x.get("@type", "") in ["Document",]
+                        if x.get("@type", "") in ["Document", ]
                     ]
                     if children:
                         data["items"] = children

--- a/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
+++ b/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
@@ -22,8 +22,10 @@ TRASPARENZA_FIELDS = [
     "dove_rivolgersi_extra",
     "fine_termine",
     "silenzio_assenso",
+    "ufficio_responsabile",
     "provvedimento_finale",
     "organo_competente_provvedimento_finale",
+    "modalita_richiesta_informazioni",
     "procedura_online",
     "altre_modalita_invio",
     "atti_documenti_corredo",
@@ -33,7 +35,7 @@ TRASPARENZA_FIELDS = [
     "titolare_potere_sostitutivo",
     "customer_satisfaction",
     "riferimenti_normativi",
-    "tempo medio",
+    "tempo_medio",
     "file_correlato",
     "responsabile_procedimento",
     "dirigente",
@@ -94,7 +96,7 @@ class TrasparenzaItems(object):
                     children = [
                         x
                         for x in self.get_trasparenza_data(context=child)
-                        if x.get("@type", "") in ["Document", ]
+                        if x.get("@type", "") in ["Document",]
                     ]
                     if children:
                         data["items"] = children

--- a/src/design/plone/contenttypes/restapi/services/types/get.py
+++ b/src/design/plone/contenttypes/restapi/services/types/get.py
@@ -110,6 +110,7 @@ FIELDSETS_ORDER = {
         "settings",
         "ownership",
         "dates",
+        "trasparenza",
     ],
     "UnitaOrganizzativa": [
         "default",

--- a/src/design/plone/contenttypes/tests/test_ct_servizio.py
+++ b/src/design/plone/contenttypes/tests/test_ct_servizio.py
@@ -72,6 +72,7 @@ class TestServizio(unittest.TestCase):
                 "design.plone.contenttypes.behavior.argomenti",
                 "design.plone.contenttypes.behavior.additional_help_infos",
                 "collective.dexteritytextindexer",
+                "design.plone.contenttypes.behavior.trasparenza",
             ),
         )
 

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -67,3 +67,6 @@ pycountry = 19.8.18
 # Required by:
 # prompt-toolkit==1.0.18
 wcwidth = 0.2.5
+
+# Added by buildout at 2020-11-18 12:12:08.764534
+keyring = 21.5.0


### PR DESCRIPTION
aggiunti un behavior per amministrazione trasparente nei servizi
aggiunto un service @trasparenza-items per recuperare l'alberatura fino al secondo livello per la pagina principale dell'amministrazione trasparente
aggiunto un service @trasparenza per recuperare le info per la creazione della pagina dinamica contenente i dettagli dei procedimenti
aggiunte due viste per avere. diversi layout del CT Document al servizio di pagine specifiche dell'amministrazione trasparente