### PR TITLE
Aggiunta della behavior plone.translatable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added behavior `plone.translatable` by default on almost all the content
+  types.
+  [arsenico13]
 
 
 2.0.2 (2021-03-24)

--- a/src/design/plone/contenttypes/profiles/default/metadata.xml
+++ b/src/design/plone/contenttypes/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <metadata>
-    <version>2002</version>
+    <version>2003</version>
   <dependencies>
     <dependency>profile-redturtle.bandi:default</dependency>
     <dependency>profile-collective.venue:default</dependency>

--- a/src/design/plone/contenttypes/profiles/default/types/Bando.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Bando.xml
@@ -8,6 +8,7 @@
  <property name="behaviors" purge="False">
     <element value="design.plone.contenttypes.behavior.argomenti_bando"/>
     <element value="collective.dexteritytextindexer"/>
+    <element value="plone.translatable"/>
     <element value="design.plone.contenttypes.behavior.servizi_correlati" remove="True"/>
     <element value="plone.richtext" remove="True" />
  </property>

--- a/src/design/plone/contenttypes/profiles/default/types/CartellaModulistica.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/CartellaModulistica.xml
@@ -48,6 +48,7 @@
     <element value="plone.basic"/>
     <element value="plone.locking" />
     <element value="volto.blocks" />
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Dataset.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Dataset.xml
@@ -47,6 +47,7 @@
     <element value="plone.categorization"/>
     <element value="plone.basic"/>
     <element value="plone.locking" />
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Document.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Document.xml
@@ -3,6 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="behaviors" purge="False">
   <element value="design.plone.contenttypes.behavior.info_testata"/>
+  <element value="plone.translatable"/>
  </property>
    <property name="view_methods">
     <element value="document_view" />

--- a/src/design/plone/contenttypes/profiles/default/types/Documento.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Documento.xml
@@ -47,6 +47,7 @@
     <element value="design.plone.contenttypes.behavior.descrizione_estesa_documento" />
     <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
     <element value="collective.dexteritytextindexer"/>
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Event.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Event.xml
@@ -29,6 +29,7 @@
     <element value="plone.locking" />
     <element value="plone.constraintypes" />
     <element value="collective.dexteritytextindexer"/>
+    <element value="plone.translatable"/>
     <!-- remove unused behaviors -->
     <element value="plone.eventlocation" remove="True" />
     <element value="plone.eventattendees" remove="True" />

--- a/src/design/plone/contenttypes/profiles/default/types/Link.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Link.xml
@@ -7,5 +7,6 @@
 
   <property name="behaviors" purge="false">
     <element value="plone.leadimage"/>
+    <element value="plone.translatable"/>
   </property>
 </object>

--- a/src/design/plone/contenttypes/profiles/default/types/Messaggio.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Messaggio.xml
@@ -48,6 +48,7 @@
     <element value="plone.basic"/>
     <element value="plone.locking" />
     <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Modulo.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Modulo.xml
@@ -39,6 +39,7 @@
     <element value="plone.relateditems" />
     <element value="plone.locking" />
     <element value="design.plone.contenttypes.behavior.multi_file" />
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/News_Item.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/News_Item.xml
@@ -21,6 +21,7 @@
    <element value="plone.locking"/>
    <element value="plone.constraintypes"/>
    <element value="collective.dexteritytextindexer"/>
+   <element value="plone.translatable"/>
  </property>
- 
+
 </object>

--- a/src/design/plone/contenttypes/profiles/default/types/Pagina_Argomento.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Pagina_Argomento.xml
@@ -51,6 +51,7 @@
     <element value="plone.leadimage" />
     <element value="collective.dexteritytextindexer"/>
     <element value="volto.blocks" />
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Persona.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Persona.xml
@@ -50,6 +50,7 @@
     <element value="plone.locking" />
     <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
     <element value="collective.dexteritytextindexer"/>
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Pratica.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Pratica.xml
@@ -47,6 +47,7 @@
     <element value="plone.categorization"/>
     <element value="plone.basic"/>
     <element value="plone.locking" />
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Servizio.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Servizio.xml
@@ -50,6 +50,7 @@
     <element value="design.plone.contenttypes.behavior.argomenti"/>
     <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
     <element value="collective.dexteritytextindexer"/>
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/UnitaOrganizzativa.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/UnitaOrganizzativa.xml
@@ -52,6 +52,7 @@
     <element value="design.plone.contenttypes.behavior.argomenti"/>
     <element value="collective.dexteritytextindexer"/>
     <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
+    <element value="plone.translatable"/>
   </property>
 
   <!-- View information -->

--- a/src/design/plone/contenttypes/profiles/default/types/Venue.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Venue.xml
@@ -17,6 +17,8 @@
   <element value="design.plone.contenttypes.behavior.geolocation_venue"/>
   <element value="design.plone.contenttypes.behavior.additional_help_infos"/>
   <element value="collective.dexteritytextindexer"/>
+  <element value="plone.translatable"/>
+  <!-- remove unused behaviors -->
   <element value="collective.address.behaviors.IContact" remove="True"/>
   <element value="collective.address.behaviors.ISocial" remove="True"/>
   <element value="design.plone.contenttypes.behavior.servizi_correlati" remove="True"/>

--- a/src/design/plone/contenttypes/testing.py
+++ b/src/design/plone/contenttypes/testing.py
@@ -53,6 +53,7 @@ class DesignPloneContenttypesLayer(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, "design.plone.contenttypes:default")
+        applyProfile(portal, "plone.app.caching:default")
 
 
 DESIGN_PLONE_CONTENTTYPES_FIXTURE = DesignPloneContenttypesLayer()
@@ -94,6 +95,7 @@ class DesignPloneContenttypesRestApiLayer(PloneRestApiDXLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, "design.plone.contenttypes:default")
+        applyProfile(portal, "plone.app.caching:default")
 
 
 DESIGN_PLONE_CONTENTTYPES_API_FIXTURE = DesignPloneContenttypesRestApiLayer()

--- a/src/design/plone/contenttypes/testing.py
+++ b/src/design/plone/contenttypes/testing.py
@@ -39,6 +39,7 @@ class DesignPloneContenttypesLayer(PloneSandboxLayer):
         self.loadZCML(
             package=design.plone.contenttypes, context=configurationContext
         )
+        self.loadZCML(package=plone.app.caching)
         self.loadZCML(package=plone.formwidget.geolocation)
         self.loadZCML(package=plone.restapi)
         self.loadZCML(package=redturtle.volto)
@@ -85,6 +86,7 @@ class DesignPloneContenttypesRestApiLayer(PloneRestApiDXLayer):
         self.loadZCML(package=collective.volto.cookieconsent)
         self.loadZCML(package=design.plone.contenttypes)
         self.loadZCML(name="overrides.zcml", package=design.plone.contenttypes)
+        self.loadZCML(package=plone.app.caching)
         self.loadZCML(package=plone.formwidget.geolocation)
         self.loadZCML(package=plone.restapi)
         self.loadZCML(package=redturtle.volto)

--- a/src/design/plone/contenttypes/testing.py
+++ b/src/design/plone/contenttypes/testing.py
@@ -14,10 +14,12 @@ import collective.venue
 import collective.volto.blocksfield
 import collective.volto.cookieconsent
 import design.plone.contenttypes
+import plone.app.caching
 import plone.formwidget.geolocation
 import plone.restapi
 import redturtle.bandi
 import redturtle.volto
+
 from zope.configuration import xmlconfig
 
 

--- a/src/design/plone/contenttypes/testing.py
+++ b/src/design/plone/contenttypes/testing.py
@@ -52,8 +52,8 @@ class DesignPloneContenttypesLayer(PloneSandboxLayer):
         self.loadZCML(package=redturtle.bandi)
 
     def setUpPloneSite(self, portal):
-        applyProfile(portal, "design.plone.contenttypes:default")
         applyProfile(portal, "plone.app.caching:default")
+        applyProfile(portal, "design.plone.contenttypes:default")
 
 
 DESIGN_PLONE_CONTENTTYPES_FIXTURE = DesignPloneContenttypesLayer()
@@ -94,8 +94,8 @@ class DesignPloneContenttypesRestApiLayer(PloneRestApiDXLayer):
         self.loadZCML(package=redturtle.bandi)
 
     def setUpPloneSite(self, portal):
-        applyProfile(portal, "design.plone.contenttypes:default")
         applyProfile(portal, "plone.app.caching:default")
+        applyProfile(portal, "design.plone.contenttypes:default")
 
 
 DESIGN_PLONE_CONTENTTYPES_API_FIXTURE = DesignPloneContenttypesRestApiLayer()

--- a/src/design/plone/contenttypes/tests/test_behavior_luogo.py
+++ b/src/design/plone/contenttypes/tests/test_behavior_luogo.py
@@ -43,8 +43,8 @@ class LuogoBehaviorIndexerFunctionalTest(unittest.TestCase):
 
     def test_luogo_behavior_fields_inexed_for_venue(self):
         # Non sembra deterministico il testing delle cose indicizzate con
-        #  collective.dexteritytextindexer. Per ora togliamo. Poi se capiamo come
-        # gestire lo rimetteremo.
+        # collective.dexteritytextindexer. Per ora togliamo. Poi se capiamo
+        # come gestire lo rimetteremo.
         return
         self.assertTrue(True)
         res = api.content.find(UID=self.venue.UID())

--- a/src/design/plone/contenttypes/tests/test_ct_cartella_modulistica.py
+++ b/src/design/plone/contenttypes/tests/test_ct_cartella_modulistica.py
@@ -29,6 +29,7 @@ class TestDocument(unittest.TestCase):
                 "plone.basic",
                 "plone.locking",
                 "volto.blocks",
+                "plone.translatable",
             ),
         )
 

--- a/src/design/plone/contenttypes/tests/test_ct_document.py
+++ b/src/design/plone/contenttypes/tests/test_ct_document.py
@@ -31,5 +31,6 @@ class TestDocument(unittest.TestCase):
                 "plone.constraintypes",
                 "volto.blocks",
                 "design.plone.contenttypes.behavior.info_testata",
+                "plone.translatable",
             ),
         )

--- a/src/design/plone/contenttypes/tests/test_ct_documento.py
+++ b/src/design/plone/contenttypes/tests/test_ct_documento.py
@@ -32,6 +32,7 @@ class TestDocument(unittest.TestCase):
                 "design.plone.contenttypes.behavior.descrizione_estesa_documento",
                 "design.plone.contenttypes.behavior.additional_help_infos",
                 "collective.dexteritytextindexer",
+                "plone.translatable",
             ),
         )
 

--- a/src/design/plone/contenttypes/tests/test_ct_event.py
+++ b/src/design/plone/contenttypes/tests/test_ct_event.py
@@ -48,6 +48,7 @@ class TestEvent(unittest.TestCase):
                 "plone.locking",
                 "plone.constraintypes",
                 "collective.dexteritytextindexer",
+                "plone.translatable",
             ),
         )
 

--- a/src/design/plone/contenttypes/tests/test_ct_luogo.py
+++ b/src/design/plone/contenttypes/tests/test_ct_luogo.py
@@ -44,6 +44,7 @@ class TestLuogo(unittest.TestCase):
                 "design.plone.contenttypes.behavior.geolocation_venue",
                 "design.plone.contenttypes.behavior.additional_help_infos",
                 "collective.dexteritytextindexer",
+                "plone.translatable",
             ),
         )
 

--- a/src/design/plone/contenttypes/tests/test_ct_modulo.py
+++ b/src/design/plone/contenttypes/tests/test_ct_modulo.py
@@ -27,5 +27,6 @@ class TestDocument(unittest.TestCase):
                 "plone.relateditems",
                 "plone.locking",
                 "design.plone.contenttypes.behavior.multi_file",
+                "plone.translatable",
             ),
         )

--- a/src/design/plone/contenttypes/tests/test_ct_news.py
+++ b/src/design/plone/contenttypes/tests/test_ct_news.py
@@ -43,6 +43,7 @@ class TestNews(unittest.TestCase):
                 "plone.locking",
                 "plone.constraintypes",
                 "collective.dexteritytextindexer",
+                "plone.translatable",
             ),
         )
 

--- a/src/design/plone/contenttypes/tests/test_ct_pagina_argomento.py
+++ b/src/design/plone/contenttypes/tests/test_ct_pagina_argomento.py
@@ -32,5 +32,6 @@ class TestPaginaArgomento(unittest.TestCase):
                 "plone.leadimage",
                 "collective.dexteritytextindexer",
                 "volto.blocks",
+                "plone.translatable",
             ),
         )

--- a/src/design/plone/contenttypes/tests/test_ct_persona.py
+++ b/src/design/plone/contenttypes/tests/test_ct_persona.py
@@ -45,6 +45,7 @@ class TestPersona(unittest.TestCase):
                 "plone.locking",
                 "design.plone.contenttypes.behavior.additional_help_infos",
                 "collective.dexteritytextindexer",
+                "plone.translatable",
             ),
         )
 

--- a/src/design/plone/contenttypes/tests/test_ct_servizio.py
+++ b/src/design/plone/contenttypes/tests/test_ct_servizio.py
@@ -71,6 +71,7 @@ class TestServizio(unittest.TestCase):
                 "design.plone.contenttypes.behavior.argomenti",
                 "design.plone.contenttypes.behavior.additional_help_infos",
                 "collective.dexteritytextindexer",
+                "plone.translatable",
             ),
         )
 

--- a/src/design/plone/contenttypes/tests/test_ct_unita_organizzativa.py
+++ b/src/design/plone/contenttypes/tests/test_ct_unita_organizzativa.py
@@ -153,6 +153,7 @@ class TestUO(unittest.TestCase):
                 "design.plone.contenttypes.behavior.argomenti",
                 "collective.dexteritytextindexer",
                 "design.plone.contenttypes.behavior.additional_help_infos",
+                "plone.translatable",
             ),
         )
 

--- a/src/design/plone/contenttypes/upgrades/configure.zcml
+++ b/src/design/plone/contenttypes/upgrades/configure.zcml
@@ -219,4 +219,14 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+    source="2002"
+    destination="2003"
+    profile="design.plone.contenttypes:default">
+      <genericsetup:upgradeStep
+        title="Update types info: new behavior added by default"
+        handler=".upgrades.update_types"
+        />
+  </genericsetup:upgradeSteps>
+
 </configure>

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -12,9 +12,10 @@ plone.testing = 7.0.1
 flake8 = 3.3.0
 pyflakes = 1.5.0
 pycodestyle = 2.3.1
-plone.restapi = 
+plone.restapi =
 plone.schema = 1.2.1
 SecretStorage = 3.2
+plone.app.caching = 3.0.0a3
 
 # Added by buildout at 2020-11-12 10:30:35.575262
 Products.PloneHotfix20200121 = 1.1


### PR DESCRIPTION
`plone.translatable` su (quasi) tutti i content type qui presenti.

Sono rimasti fuori solo:

- cartella approfondimento
- documento personale
- ricevuta pagamento


Con upgrade step.