### PR TITLE
Cartella modulistica enable file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 3.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- You can now add "File" content type inside a CartellaModulistica.
+  [arsenico13]
 
 
 3.4.0 (2021-07-07)

--- a/src/design/plone/contenttypes/profiles/default/metadata.xml
+++ b/src/design/plone/contenttypes/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <metadata>
-    <version>3400</version>
+    <version>3401</version>
   <dependencies>
     <dependency>profile-redturtle.bandi:default</dependency>
     <dependency>profile-collective.venue:default</dependency>

--- a/src/design/plone/contenttypes/profiles/default/types/CartellaModulistica.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/CartellaModulistica.xml
@@ -25,6 +25,7 @@
     <element value="Documento" />
     <element value="Link" />
     <element value="Image" />
+    <element value="File" />
   </property>
   <!-- Schema, class and security -->
   <property name="add_permission">design.plone.contenttypes.AddCartellaModulistica</property>

--- a/src/design/plone/contenttypes/tests/test_ct_cartella_modulistica.py
+++ b/src/design/plone/contenttypes/tests/test_ct_cartella_modulistica.py
@@ -38,6 +38,6 @@ class TestCartellaModulistica(unittest.TestCase):
     def test_event_addable_types(self):
         portal_types = api.portal.get_tool(name="portal_types")
         self.assertEqual(
-            ("Document", "Documento", "Link", "Image"),
+            ("Document", "Documento", "Link", "Image", "File"),
             portal_types["CartellaModulistica"].allowed_content_types,
         )

--- a/src/design/plone/contenttypes/upgrades/configure.zcml
+++ b/src/design/plone/contenttypes/upgrades/configure.zcml
@@ -319,4 +319,13 @@
         handler=".upgrades.to_3400"
       />
   </genericsetup:upgradeSteps>
+  <genericsetup:upgradeSteps
+    source="3400"
+    destination="3401"
+    profile="design.plone.contenttypes:default">
+      <genericsetup:upgradeStep
+        title="Enable File to be added inside CartellaModulistica"
+        handler=".upgrades.to_3401"
+      />
+  </genericsetup:upgradeSteps>
 </configure>

--- a/src/design/plone/contenttypes/upgrades/upgrades.py
+++ b/src/design/plone/contenttypes/upgrades/upgrades.py
@@ -656,3 +656,8 @@ def to_3400(context):  # noqa: C901
                     if blocks:
                         fix_block(blocks, brain.getURL())
                         setattr(item, name, value)
+
+
+def to_3401(context):  # noqa: C901
+    logger.info("File type can now be added inside a CartellaModulistica")
+    update_types(context)


### PR DESCRIPTION
All'interno di un contenuto di tipo CartellaModulistica è ora possibile aggiungere anche File.