### PR TITLE
Fix ordinamento bandi, us 24062

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 3.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Bandi folder deepening now returns actual children order in parent instead of being ordered by title.
+  [deodorhunter]
 
 
 3.9.0 (2021-12-27)

--- a/src/design/plone/contenttypes/restapi/serializers/bando.py
+++ b/src/design/plone/contenttypes/restapi/serializers/bando.py
@@ -19,7 +19,7 @@ class BandoSerializer(BaseSerializer):
             contents = bando_view.retrieveContentsOfFolderDeepening(folder["path"])
             folder.update({"children": contents})
             results.append(folder)
-        return sorted(results, key=lambda k: k["title"])
+        return results
 
     def __call__(self, version=None, include_items=True):
         result = super(BandoSerializer, self).__call__(


### PR DESCRIPTION
[fix] attachments folders inside bando now are returned in parent actual order instead than being sorted by title