### PR TITLE
[fix] fixed tipologia_notizia field

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
       - id: black
 #        args: ["--line-length=88", "--check", "--diff", "--force-exclude=migrations", "src/"]

--- a/src/design/plone/contenttypes/behaviors/additional_help_infos.py
+++ b/src/design/plone/contenttypes/behaviors/additional_help_infos.py
@@ -14,7 +14,6 @@ from zope.interface import provider
 # e bisognerebbe metterlo unifrme per tutti in barba alle linee guida
 @provider(IFormFieldProvider)
 class IAdditionalHelpInfos(model.Schema):
-
     ulteriori_informazioni = BlocksField(
         title=_("ulteriori_informazioni", default="Ulteriori informazioni"),
         description=_(

--- a/src/design/plone/contenttypes/behaviors/argomenti.py
+++ b/src/design/plone/contenttypes/behaviors/argomenti.py
@@ -143,7 +143,6 @@ class IArgomentiEvento(IArgomentiSchema):
 
 @provider(IFormFieldProvider)
 class IArgomentiServizio(IArgomentiSchema):
-
     tassonomia_argomenti = RelationList(
         title=_("tassonomia_argomenti_label", default="Argomenti"),
         description=_(

--- a/src/design/plone/contenttypes/behaviors/dataset_correlati.py
+++ b/src/design/plone/contenttypes/behaviors/dataset_correlati.py
@@ -15,7 +15,6 @@ from zope.interface import provider
 # TODO: merge with NEWS
 @provider(IFormFieldProvider)
 class IDatasetCorrelati(model.Schema):
-
     dataset_correlati = RelationList(
         title=_("dataset_correlati_label", default="Dataset correlati"),
         description=_(

--- a/src/design/plone/contenttypes/behaviors/geolocation.py
+++ b/src/design/plone/contenttypes/behaviors/geolocation.py
@@ -13,7 +13,6 @@ from zope.interface import provider
 
 @provider(IFormFieldProvider)
 class IGeolocatableUnitaOrganizzativa(IGeolocatable):
-
     model.fieldset(
         "contatti",
         label=_("contatti_label", default="Contatti"),
@@ -23,7 +22,6 @@ class IGeolocatableUnitaOrganizzativa(IGeolocatable):
 
 @provider(IFormFieldProvider)
 class IGeolocatableVenue(IGeolocatable):
-
     model.fieldset(
         "dove", label=_("dove_label", default="Dove"), fields=["geolocation"]
     )
@@ -31,7 +29,6 @@ class IGeolocatableVenue(IGeolocatable):
 
 @provider(IFormFieldProvider)
 class IGeolocatableEvent(IGeolocatable):
-
     model.fieldset(
         "luogo",
         label=_("luogo_label", default="Luogo"),

--- a/src/design/plone/contenttypes/behaviors/luoghi_correlati.py
+++ b/src/design/plone/contenttypes/behaviors/luoghi_correlati.py
@@ -14,7 +14,6 @@ from zope.interface import provider
 
 # TODO: merge with NEWS
 class ILuoghiCorrelatiSchema(model.Schema):
-
     luoghi_correlati = RelationList(
         title=_("luoghi_correlati_label", default="Luoghi correlati"),
         description=_(

--- a/src/design/plone/contenttypes/behaviors/servizi_correlati.py
+++ b/src/design/plone/contenttypes/behaviors/servizi_correlati.py
@@ -15,7 +15,6 @@ from zope.interface import provider
 # TODO: merge with NEWS
 @provider(IFormFieldProvider)
 class IServiziCorrelati(model.Schema):
-
     servizi_correlati = RelationList(
         title=_("servizi_correlati_label", default="Servizi correlati"),
         description=_(

--- a/src/design/plone/contenttypes/behaviors/show_modified.py
+++ b/src/design/plone/contenttypes/behaviors/show_modified.py
@@ -19,7 +19,6 @@ def showModifiedDefaultValue(context=None):
 
 @provider(IFormFieldProvider)
 class IShowModified(model.Schema):
-
     show_modified = schema.Bool(
         title=_("show_modified_label", default="Mostra la data di ultima modifica"),
         description=_(

--- a/src/design/plone/contenttypes/behaviors/strutture_correlate.py
+++ b/src/design/plone/contenttypes/behaviors/strutture_correlate.py
@@ -14,7 +14,6 @@ from zope.interface import provider
 
 @provider(IFormFieldProvider)
 class IStruttureCorrelate(model.Schema):
-
     strutture_politiche = RelationList(
         title="Strutture politiche coinvolte",
         default=[],

--- a/src/design/plone/contenttypes/browser/manage_content/check_servizi.py
+++ b/src/design/plone/contenttypes/browser/manage_content/check_servizi.py
@@ -26,7 +26,6 @@ class ISearchForm(Interface):
 
 @implementer(ISearchForm)
 class CheckServizi(form.Form):
-
     ignoreContext = True
     # template = ViewPageTemplateFile("templates/check_servizi.pt")
     prefix = ""

--- a/src/design/plone/contenttypes/events/common.py
+++ b/src/design/plone/contenttypes/events/common.py
@@ -2,7 +2,6 @@
 
 
 def onModify(context, event):
-
     for description in event.descriptions:
         if "IBasic.title" in getattr(description, "attributes", []):
             for child in context.listFolderContents():

--- a/src/design/plone/contenttypes/indexers/bando.py
+++ b/src/design/plone/contenttypes/indexers/bando.py
@@ -11,5 +11,4 @@ def ufficio_responsabile_bando(context, **kw):
 
 @indexer(IBandoAgidSchema)
 def Subject_bando(context, **kw):
-
     return context.Subject

--- a/src/design/plone/contenttypes/interfaces/servizio.py
+++ b/src/design/plone/contenttypes/interfaces/servizio.py
@@ -16,7 +16,6 @@ from zope import schema
 
 
 class ITempiEScadenzeValueSchema(model.Schema):
-
     milestone = schema.TextLine(
         title=_("milestone_label", default="Titolo"),
         required=True,

--- a/src/design/plone/contenttypes/patches/baseserializer.py
+++ b/src/design/plone/contenttypes/patches/baseserializer.py
@@ -10,6 +10,7 @@ We need a solution like that because for some different reasons:
    SerializeToJson and SerializeFolderToJson classes
 """
 
+from collective.taxonomy import PATH_SEPARATOR
 from collective.taxonomy.interfaces import ITaxonomy
 from plone import api
 from plone.restapi.batching import HypermediaBatch
@@ -34,12 +35,16 @@ def design_italia_serialize_to_json_call(self, version=None, include_items=True)
     )
 
     if self.context.portal_type == "News Item":
-        taxonomy = getUtility(ITaxonomy, name="collective.taxonomy.tipologia_notizia")
-        taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
+        if self.context.tipologia_notizia:
+            taxonomy = getUtility(
+                ITaxonomy, name="collective.taxonomy.tipologia_notizia"
+            )
+            taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
 
-        result["design_italia_meta_type"] = taxonomy_voc.inv_data.get(
-            self.context.tipologia_notizia[0], None
-        )
+            title = taxonomy_voc.inv_data.get(self.context.tipologia_notizia[0], None)
+
+            if title.startswith(PATH_SEPARATOR):
+                result["design_italia_meta_type"] = title.replace(PATH_SEPARATOR, "", 1)
     else:
         result["design_italia_meta_type"] = translate(
             ttool[self.context.portal_type].Title(), context=self.request

--- a/src/design/plone/contenttypes/patches/patches.py
+++ b/src/design/plone/contenttypes/patches/patches.py
@@ -2,7 +2,6 @@ from collective.taxonomy.vocabulary import Vocabulary
 
 
 def eea_api_taxonomy_taxonomy_call(self, context):
-
     if not self.data:
         return Vocabulary(self.name, {}, {}, {}, 2)
 

--- a/src/design/plone/contenttypes/restapi/deserializers/documento.py
+++ b/src/design/plone/contenttypes/restapi/deserializers/documento.py
@@ -54,7 +54,6 @@ class DeserializeDocumentoFromJson(DeserializeFromJson):
     def __call__(
         self, validate_all=False, data=None, create=False
     ):  # noqa: ignore=C901
-
         if data is None:
             data = json_body(self.request)
 

--- a/src/design/plone/contenttypes/restapi/deserializers/news.py
+++ b/src/design/plone/contenttypes/restapi/deserializers/news.py
@@ -53,7 +53,6 @@ class DeserializeNewsFromJson(DeserializeFromJson):
     def __call__(
         self, validate_all=False, data=None, create=False
     ):  # noqa: ignore=C901
-
         if data is None:
             data = json_body(self.request)
 

--- a/src/design/plone/contenttypes/restapi/deserializers/persona.py
+++ b/src/design/plone/contenttypes/restapi/deserializers/persona.py
@@ -23,7 +23,6 @@ class DeserializePersonaFromJson(DeserializeFromJson):
     def __call__(
         self, validate_all=False, data=None, create=False
     ):  # noqa: ignore=C901
-
         if data is None:
             data = json_body(self.request)
         if data:

--- a/src/design/plone/contenttypes/restapi/deserializers/servizio.py
+++ b/src/design/plone/contenttypes/restapi/deserializers/servizio.py
@@ -57,7 +57,6 @@ class DeserializeServizioFromJson(DeserializeFromJson):
     def __call__(
         self, validate_all=False, data=None, create=False
     ):  # noqa: ignore=C901
-
         if data is None:
             data = json_body(self.request)
 

--- a/src/design/plone/contenttypes/restapi/deserializers/unitaorganizzativa.py
+++ b/src/design/plone/contenttypes/restapi/deserializers/unitaorganizzativa.py
@@ -51,7 +51,6 @@ class DeserializeUnitaOrganizzativaFromJson(DeserializeFromJson):
     def __call__(
         self, validate_all=False, data=None, create=False
     ):  # noqa: ignore=C901
-
         if data is None:
             data = json_body(self.request)
 

--- a/src/design/plone/contenttypes/restapi/deserializers/venue.py
+++ b/src/design/plone/contenttypes/restapi/deserializers/venue.py
@@ -51,7 +51,6 @@ class DeserializeLuogoFromJson(DeserializeFromJson):
     def __call__(
         self, validate_all=False, data=None, create=False
     ):  # noqa: ignore=C901
-
         if data is None:
             data = json_body(self.request)
 
@@ -105,7 +104,6 @@ class DeserializeLuogoFromJson(DeserializeFromJson):
                     errors.append(new_error("Il campo {} è obbligatorio".format(field)))
 
         if is_patch:
-
             # Title validation
             if "title" in data and not title:
                 errors.append(new_error("Il titolo del luogo è obbligatorio"))

--- a/src/design/plone/contenttypes/restapi/serializers/dxcontent.py
+++ b/src/design/plone/contenttypes/restapi/serializers/dxcontent.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collective.taxonomy.interfaces import ITaxonomy
 from design.plone.contenttypes.interfaces import IDesignPloneContenttypesLayer
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
@@ -9,6 +10,7 @@ from plone.restapi.serializer.dxcontent import (
 )
 from plone.restapi.serializer.dxcontent import SerializeToJson as BaseSerializer
 from zope.component import adapter
+from zope.component import getUtility
 from zope.i18n import translate
 from zope.interface import implementer
 
@@ -22,7 +24,14 @@ class SerializeToJson(BaseSerializer):
         )
         ttool = api.portal.get_tool("portal_types")
         if self.context.portal_type == "News Item":
-            result["design_italia_meta_type"] = self.context.tipologia_notizia
+            taxonomy = getUtility(
+                ITaxonomy, name="collective.taxonomy.tipologia_notizia"
+            )
+            taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
+
+            result["design_italia_meta_type"] = taxonomy_voc.inv_data.get(
+                self.context.tipologia_notizia[0], None
+            )
         else:
             result["design_italia_meta_type"] = translate(
                 ttool[self.context.portal_type].Title(), context=self.request
@@ -39,13 +48,16 @@ class SerializeFolderToJson(BaseFolderSerializer):
         )
         result["@id"] = self.context.absolute_url()
         ttool = api.portal.get_tool("portal_types")
+
         if self.context.portal_type == "News Item":
-            try:
-                tipologia_news = self.context.tipologia_notizia
-            except AttributeError:
-                # fallback if we don't have c.taxonomy configured yet
-                tipologia_news = self.context.tipologia_notizia
-            result["design_italia_meta_type"] = tipologia_news
+            taxonomy = getUtility(
+                ITaxonomy, name="collective.taxonomy.tipologia_notizia"
+            )
+            taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
+
+            result["design_italia_meta_type"] = taxonomy_voc.inv_data.get(
+                self.context.tipologia_notizia[0], None
+            )
         else:
             result["design_italia_meta_type"] = translate(
                 ttool[self.context.portal_type].Title(), context=self.request

--- a/src/design/plone/contenttypes/restapi/serializers/dxcontent.py
+++ b/src/design/plone/contenttypes/restapi/serializers/dxcontent.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collective.taxonomy import PATH_SEPARATOR
 from collective.taxonomy.interfaces import ITaxonomy
 from design.plone.contenttypes.interfaces import IDesignPloneContenttypesLayer
 from plone import api
@@ -24,14 +25,20 @@ class SerializeToJson(BaseSerializer):
         )
         ttool = api.portal.get_tool("portal_types")
         if self.context.portal_type == "News Item":
-            taxonomy = getUtility(
-                ITaxonomy, name="collective.taxonomy.tipologia_notizia"
-            )
-            taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
+            if self.context.tipologia_notizia:
+                taxonomy = getUtility(
+                    ITaxonomy, name="collective.taxonomy.tipologia_notizia"
+                )
+                taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
 
-            result["design_italia_meta_type"] = taxonomy_voc.inv_data.get(
-                self.context.tipologia_notizia[0], None
-            )
+                title = taxonomy_voc.inv_data.get(
+                    self.context.tipologia_notizia[0], None
+                )
+
+                if title.startswith(PATH_SEPARATOR):
+                    result["design_italia_meta_type"] = title.replace(
+                        PATH_SEPARATOR, "", 1
+                    )
         else:
             result["design_italia_meta_type"] = translate(
                 ttool[self.context.portal_type].Title(), context=self.request
@@ -50,14 +57,20 @@ class SerializeFolderToJson(BaseFolderSerializer):
         ttool = api.portal.get_tool("portal_types")
 
         if self.context.portal_type == "News Item":
-            taxonomy = getUtility(
-                ITaxonomy, name="collective.taxonomy.tipologia_notizia"
-            )
-            taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
+            if self.context.tipologia_notizia:
+                taxonomy = getUtility(
+                    ITaxonomy, name="collective.taxonomy.tipologia_notizia"
+                )
+                taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
 
-            result["design_italia_meta_type"] = taxonomy_voc.inv_data.get(
-                self.context.tipologia_notizia[0], None
-            )
+                title = taxonomy_voc.inv_data.get(
+                    self.context.tipologia_notizia[0], None
+                )
+
+                if title.startswith(PATH_SEPARATOR):
+                    result["design_italia_meta_type"] = title.replace(
+                        PATH_SEPARATOR, "", 1
+                    )
         else:
             result["design_italia_meta_type"] = translate(
                 ttool[self.context.portal_type].Title(), context=self.request

--- a/src/design/plone/contenttypes/restapi/serializers/summary.py
+++ b/src/design/plone/contenttypes/restapi/serializers/summary.py
@@ -171,16 +171,19 @@ class DefaultJSONSummarySerializer(BaseSerializer):
 
     def get_design_meta_type(self):
         ttool = api.portal.get_tool("portal_types")
-        if self.context.portal_type == "News Item" and self.context.tipologia_notizia:
-            taxonomy = getUtility(
-                ITaxonomy, name="collective.taxonomy.tipologia_notizia"
-            )
-            taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
-            title = taxonomy_voc.inv_data.get(self.context.tipologia_notizia[0], None)
-            if title.startswith(PATH_SEPARATOR):
-                title = title.replace(PATH_SEPARATOR, "", 1)
+        if self.context.portal_type == "News Item":
+            if self.context.tipologia_notizia:
+                taxonomy = getUtility(
+                    ITaxonomy, name="collective.taxonomy.tipologia_notizia"
+                )
+                taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
+                title = taxonomy_voc.inv_data.get(
+                    self.context.tipologia_notizia[0], None
+                )
+                if title.startswith(PATH_SEPARATOR):
+                    title = title.replace(PATH_SEPARATOR, "", 1)
 
-            return title
+                return title
         else:
             return translate(
                 ttool[self.context.portal_type].Title(), context=self.request

--- a/src/design/plone/contenttypes/restapi/serializers/summary.py
+++ b/src/design/plone/contenttypes/restapi/serializers/summary.py
@@ -171,13 +171,16 @@ class DefaultJSONSummarySerializer(BaseSerializer):
 
     def get_design_meta_type(self):
         ttool = api.portal.get_tool("portal_types")
-        if self.context.portal_type == "News Item":
-            # return translate(
-            #     self.context.tipologia_notizia,
-            #     domain="design.plone.contenttypes",
-            #     context=self.request,
-            # )
-            return self.context.tipologia_notizia
+        if self.context.portal_type == "News Item" and self.context.tipologia_notizia:
+            taxonomy = getUtility(
+                ITaxonomy, name="collective.taxonomy.tipologia_notizia"
+            )
+            taxonomy_voc = taxonomy.makeVocabulary(self.request.get("LANGUAGE"))
+            title = taxonomy_voc.inv_data.get(self.context.tipologia_notizia[0], None)
+            if title.startswith(PATH_SEPARATOR):
+                title = title.replace(PATH_SEPARATOR, "", 1)
+
+            return title
         else:
             return translate(
                 ttool[self.context.portal_type].Title(), context=self.request

--- a/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
+++ b/src/design/plone/contenttypes/restapi/services/trasparenza/get.py
@@ -87,7 +87,6 @@ class TrasparenzaItems(object):
             )
             data = serializer()
             if child.portal_type == "Document":
-
                 if IFolderish.providedBy(child):
                     children = [
                         x

--- a/src/design/plone/contenttypes/restapi/types/adapters.py
+++ b/src/design/plone/contenttypes/restapi/types/adapters.py
@@ -22,7 +22,6 @@ DATAGRID_FIELDS = ["value_punto_contatto", "timeline_tempi_scadenze"]
 @implementer(IJsonSchemaProvider)
 class LeadImageJsonSchemaProvider(ObjectJsonSchemaProvider):
     def get_size_vocabulary(self):
-
         factory = getUtility(
             IVocabularyFactory, "design.plone.vocabularies.leadimage_dimension"
         )

--- a/src/design/plone/contenttypes/schema_overrides.py
+++ b/src/design/plone/contenttypes/schema_overrides.py
@@ -18,7 +18,6 @@ class SchemaTweaks(object):
         self.schema = schema
 
     def __call__(self):
-
         if self.schema.getName() == "IRelatedItems":
             fieldset = Fieldset(
                 "correlati",

--- a/src/design/plone/contenttypes/tests/test_behavior_descrizione_estesa.py
+++ b/src/design/plone/contenttypes/tests/test_behavior_descrizione_estesa.py
@@ -15,7 +15,6 @@ import unittest
 
 
 class TestDescrizioneEstesaBehavior(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):
@@ -32,7 +31,6 @@ class TestDescrizioneEstesaBehavior(unittest.TestCase):
         self.api_session.close()
 
     def test_descrizione_estesa_indexed(self):
-
         # Servizio have design.plone.contenttypes.behavior.descrizione_estesa
         # behavior
         servizio = api.content.create(

--- a/src/design/plone/contenttypes/tests/test_behavior_luogo.py
+++ b/src/design/plone/contenttypes/tests/test_behavior_luogo.py
@@ -12,7 +12,6 @@ import unittest
 
 
 class LuogoBehaviorIndexerFunctionalTest(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_behavior_show_modified.py
+++ b/src/design/plone/contenttypes/tests/test_behavior_show_modified.py
@@ -17,7 +17,6 @@ import unittest
 
 
 class TestShowModifiedBehavior(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):
@@ -41,7 +40,6 @@ class TestShowModifiedBehavior(unittest.TestCase):
         transaction.commit()
 
     def test_if_not_set_return_site_default(self):
-
         page = api.content.create(
             container=self.portal,
             type="Document",
@@ -65,7 +63,6 @@ class TestShowModifiedBehavior(unittest.TestCase):
         self.assertFalse(resp.json().get("show_modified", None))
 
     def test_if_set_will_override_default(self):
-
         page = api.content.create(
             container=self.portal,
             type="Document",

--- a/src/design/plone/contenttypes/tests/test_behavior_update_note.py
+++ b/src/design/plone/contenttypes/tests/test_behavior_update_note.py
@@ -16,7 +16,6 @@ import unittest
 
 
 class TestUpdateNoteBehavior(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):
@@ -33,7 +32,6 @@ class TestUpdateNoteBehavior(unittest.TestCase):
         self.api_session.close()
 
     def test_is_enabled_in_bando(self):
-
         portal_types = api.portal.get_tool(name="portal_types")
         self.assertIn(
             "design.plone.contenttypes.behavior.update_note",

--- a/src/design/plone/contenttypes/tests/test_change_news_type.py
+++ b/src/design/plone/contenttypes/tests/test_change_news_type.py
@@ -9,7 +9,6 @@ import unittest
 
 
 class MoveNewsItemView(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_INTEGRATION_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_ct_bando.py
+++ b/src/design/plone/contenttypes/tests/test_ct_bando.py
@@ -39,7 +39,6 @@ class TestBando(unittest.TestCase):
         self.assertEqual(default_ente, ())
 
     def test_bando_substructure_created(self):
-
         bando = api.content.create(container=self.portal, type="Bando", title="Bando")
 
         self.assertIn("documenti", bando.keys())

--- a/src/design/plone/contenttypes/tests/test_ct_documento.py
+++ b/src/design/plone/contenttypes/tests/test_ct_documento.py
@@ -60,7 +60,6 @@ class TestDocument(unittest.TestCase):
 
 
 class TestDocumentoApi(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_ct_event.py
+++ b/src/design/plone/contenttypes/tests/test_ct_event.py
@@ -66,7 +66,6 @@ class TestEvent(unittest.TestCase):
 
 
 class TestEventApi(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_ct_luogo.py
+++ b/src/design/plone/contenttypes/tests/test_ct_luogo.py
@@ -59,7 +59,6 @@ class TestLuogo(unittest.TestCase):
 
 
 class TestLuogoApi(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_ct_news.py
+++ b/src/design/plone/contenttypes/tests/test_ct_news.py
@@ -63,7 +63,6 @@ class TestNews(unittest.TestCase):
 
 
 class TestNewsApi(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_ct_servizio.py
+++ b/src/design/plone/contenttypes/tests/test_ct_servizio.py
@@ -124,7 +124,6 @@ class TestServizioApi(unittest.TestCase):
         self.assertEqual(res[0].UID, servizio.UID())
 
     def test_a_chi_si_rivolge_indexed_in_searchabletext(self):
-
         #  Servizio is the only ct with this field
         servizio = api.content.create(
             container=self.portal,
@@ -139,7 +138,6 @@ class TestServizioApi(unittest.TestCase):
         self.assertEqual(res[0].UID, servizio.UID())
 
     def test_chi_puo_presentare_indexed_in_searchabletext(self):
-
         #  Servizio is the only ct with this field
         servizio = api.content.create(
             container=self.portal,
@@ -154,7 +152,6 @@ class TestServizioApi(unittest.TestCase):
         self.assertEqual(res[0].UID, servizio.UID())
 
     def test_come_si_fa_indexed_in_searchabletext(self):
-
         #  Servizio is the only ct with this field
         servizio = api.content.create(
             container=self.portal,
@@ -169,7 +166,6 @@ class TestServizioApi(unittest.TestCase):
         self.assertEqual(res[0].UID, servizio.UID())
 
     def test_cosa_si_ottiene_indexed_in_searchabletext(self):
-
         #  Servizio is the only ct with this field
         servizio = api.content.create(
             container=self.portal,
@@ -184,7 +180,6 @@ class TestServizioApi(unittest.TestCase):
         self.assertEqual(res[0].UID, servizio.UID())
 
     def test_cosa_serve_indexed_in_searchabletext(self):
-
         #  Servizio is the only ct with this field
         servizio = api.content.create(
             container=self.portal,
@@ -199,7 +194,6 @@ class TestServizioApi(unittest.TestCase):
         self.assertEqual(res[0].UID, servizio.UID())
 
     def test_ulteriori_informazioni_indexed_in_searchabletext(self):
-
         #  Servizio is the only ct with this field
         servizio = api.content.create(
             container=self.portal,

--- a/src/design/plone/contenttypes/tests/test_move_news_items_view.py
+++ b/src/design/plone/contenttypes/tests/test_move_news_items_view.py
@@ -9,7 +9,6 @@ import unittest
 
 
 class MoveNewsItemView(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_INTEGRATION_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_relateditems_with_dates.py
+++ b/src/design/plone/contenttypes/tests/test_relateditems_with_dates.py
@@ -19,7 +19,6 @@ import unittest
 
 
 class VocabulariesControlpanelTest(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):
@@ -110,7 +109,6 @@ class VocabulariesControlpanelTest(unittest.TestCase):
     def test_api_do_not_return_related_items_with_effective_date_in_future_for_anon(
         self,
     ):
-
         present = api.content.create(
             container=self.portal, type="Document", title="present"
         )

--- a/src/design/plone/contenttypes/tests/test_settings_controlpanel_api.py
+++ b/src/design/plone/contenttypes/tests/test_settings_controlpanel_api.py
@@ -12,7 +12,6 @@ import unittest
 
 
 class SettingsControlpanelTest(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_setup.py
+++ b/src/design/plone/contenttypes/tests/test_setup.py
@@ -49,7 +49,6 @@ class TestSetup(unittest.TestCase):
 
 
 class TestUninstall(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_INTEGRATION_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/tests/test_summary_serializer.py
+++ b/src/design/plone/contenttypes/tests/test_summary_serializer.py
@@ -20,7 +20,6 @@ import unittest
 
 
 class SummarySerializerTest(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):
@@ -44,7 +43,6 @@ class SummarySerializerTest(unittest.TestCase):
         self.api_session.close()
 
     def test_has_children_returned_in_get_content(self):
-
         api.content.create(container=self.document, type="Document", title="empty")
         api.content.create(container=self.document, type="Document", title="filled")
 
@@ -65,7 +63,6 @@ class SummarySerializerTest(unittest.TestCase):
         self.assertTrue(items[1]["has_children"])
 
     def test_has_children_not_returned_in_searches(self):
-
         api.content.create(container=self.document, type="Document", title="empty")
         api.content.create(container=self.document, type="Document", title="filled")
 
@@ -88,7 +85,6 @@ class SummarySerializerTest(unittest.TestCase):
         self.assertNotIn("has_children", items[1])
 
     def test_has_children_not_returned_in_backend_serialization(self):
-
         empty = api.content.create(
             container=self.document, type="Document", title="empty"
         )
@@ -151,7 +147,6 @@ class SummarySerializerTest(unittest.TestCase):
         self.assertEqual(serializer["remoteUrl"], self.document.absolute_url())
 
     def test_summary_return_persona_role(self):
-
         api.content.create(
             container=self.portal, type="Persona", title="John Doe", ruolo="unknown"
         )

--- a/src/design/plone/contenttypes/tests/test_uo_summary_serializer.py
+++ b/src/design/plone/contenttypes/tests/test_uo_summary_serializer.py
@@ -13,7 +13,6 @@ import unittest
 
 
 class UOSummarySerializerTest(unittest.TestCase):
-
     layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/src/design/plone/contenttypes/upgrades/upgrades.py
+++ b/src/design/plone/contenttypes/upgrades/upgrades.py
@@ -95,7 +95,6 @@ def remap_fields(mapping):
 
 
 def to_1001(context):
-
     update_types(context)
 
     # cleanup event behaviors
@@ -124,7 +123,6 @@ def to_1001(context):
 
 
 def to_1003(context):
-
     update_types(context)
 
     mapping = {
@@ -957,7 +955,6 @@ def to_5400(context):
 
 
 def to_5410(context):
-
     # cleanup Document behaviors
     portal_types = api.portal.get_tool(name="portal_types")
     behaviors = portal_types["Document"].behaviors
@@ -1223,7 +1220,6 @@ class colors(object):
 
 
 def to_7001(context):
-
     installer = get_installer(context=api.portal.get())
     installer.install_product("eea.api.taxonomy")
     logger.info(
@@ -1304,7 +1300,6 @@ def create_incarico_for_persona(context):
         "Altro tipo": "altro",
     }
     for brain in brains:
-
         persona = brain.getObject()
 
         incarichi_folder = persona["incarichi"]
@@ -1596,7 +1591,6 @@ def update_taxonomies_on_blocks(context):
                 for block in blocks.values():
                     if block.get("@type", "") == "listing":
                         for query in block.get("querystring", {}).get("query", []):
-
                             if query["i"] in [
                                 "tipologia_notizia",
                                 "tipologia_documento",

--- a/src/design/plone/contenttypes/vocabularies/controlapanel_vocabularies.py
+++ b/src/design/plone/contenttypes/vocabularies/controlapanel_vocabularies.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 class BaseVocabulary(object):
     def __call__(self, context):
-
         values = get_settings_for_language(field=self.field)
         if not values:
             return SimpleVocabulary([])
@@ -34,7 +33,6 @@ class LeadImageDimension(BaseVocabulary):
     field = "lead_image_dimension"
 
     def __call__(self, context):
-
         values = api.portal.get_registry_record(
             self.field, interface=IDesignPloneSettings, default=[]
         )

--- a/src/design/plone/contenttypes/vocabularies/reference_vocabularies.py
+++ b/src/design/plone/contenttypes/vocabularies/reference_vocabularies.py
@@ -10,7 +10,6 @@ from zope.site.hooks import getSite
 
 
 class ReferencesVocabulary(object):
-
     INDEX = ""
 
     def get_all_index_values(self):
@@ -32,19 +31,16 @@ class ReferencesVocabulary(object):
 
 @implementer(IVocabularyFactory)
 class EventLocationVocabulary(ReferencesVocabulary):
-
     INDEX = "event_location"
 
 
 @implementer(IVocabularyFactory)
 class OfficeLocationVocabulary(ReferencesVocabulary):
-
     INDEX = "ufficio_responsabile"
 
 
 @implementer(IVocabularyFactory)
 class UOLocationVocabulary(ReferencesVocabulary):
-
     INDEX = "uo_location"
 
 


### PR DESCRIPTION
- sistemato il dato che finisce nel campo design_italia_meta_type per prendere il titolo della tassonomia invece che il token, per quanto riguarda la tipologia_notizia