### PR TITLE
fix canale_digitale_link field type and restapi integration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 6.0.0a23 (unreleased)
 ---------------------
 
+- Add serializer/deserializer for canale_digitale_link to handle internal/external links like remoteURL field.
+  [cekk]
+- Force canale_digitale_link return `url` widget in Servizio schema.
 
 6.0.0a22 (2023-03-07)
 ---------------------

--- a/src/design/plone/contenttypes/interfaces/servizio.py
+++ b/src/design/plone/contenttypes/interfaces/servizio.py
@@ -7,6 +7,7 @@ from design.plone.contenttypes.interfaces import IDesignPloneContentType
 from plone.app.dexterity import textindexer
 from plone.app.z3cform.widget import DateFieldWidget
 from plone.app.z3cform.widget import RelatedItemsFieldWidget
+from plone.app.z3cform.widget import LinkFieldWidget
 from plone.autoform import directives as form
 from plone.namedfile import field
 from plone.supermodel import model
@@ -160,7 +161,7 @@ class IServizio(model.Schema, IDesignPloneContentType):
         required=False,
     )
 
-    canale_digitale_link = schema.URI(
+    canale_digitale_link = schema.TextLine(
         title=_("canale_digitale_link", default="Link al canale digitale"),
         description=_(
             "canale_digitale_link_help",
@@ -465,6 +466,7 @@ class IServizio(model.Schema, IDesignPloneContentType):
         DataGridFieldFactory,
         frontendOptions={"widget": "data_grid"},
     )
+    form.widget("canale_digitale_link", LinkFieldWidget)
 
     # custom fieldset and order
     model.fieldset(

--- a/src/design/plone/contenttypes/restapi/deserializers/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/deserializers/configure.zcml
@@ -7,6 +7,7 @@
   <adapter factory=".servizio.DeserializeServizioFromJson" />
   <adapter factory=".unitaorganizzativa.DeserializeUnitaOrganizzativaFromJson" />
   <adapter factory=".dxfields.GeolocationFieldDeserializer" />
+  <adapter factory=".dxfields.LinkTextLineFieldDeserializer" />
   <adapter factory=".venue.DeserializeLuogoFromJson" />
   <adapter factory=".dxfields.SourceTextDeserializer" />
   <adapter factory=".dxfields.TimelineTempiEScadenzeFieldDeserializer" />

--- a/src/design/plone/contenttypes/restapi/serializers/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/serializers/configure.zcml
@@ -23,6 +23,7 @@
   <adapter factory=".dxcontent.SerializeToJson" />
   <adapter factory=".dxfields.SourceTextSerializer" />
   <adapter factory=".dxfields.TempiEScadenzeValueSerializer" />
+  <adapter factory=".dxfields.ServizioTextLineFieldSerializer" />
   <adapter factory=".persona.PersonaSerializer" />
   <adapter factory=".related_news_serializer.ServizioSerializer" />
   <adapter factory=".relationfield.RelationListFieldSerializer" />
@@ -32,5 +33,4 @@
   <adapter factory=".documento.DocumentoSerializer" />
   <adapter factory=".cartella_modulistica.CartellaModulisticaSerializer" />
   <adapter factory=".punto_di_contatto.PuntoDiContattoSerializer" />
-  <adapter factory=".dxfields.FileFieldViewModeSerializer" />
 </configure>

--- a/src/design/plone/contenttypes/restapi/serializers/dxfields.py
+++ b/src/design/plone/contenttypes/restapi/serializers/dxfields.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from AccessControl.unauthorized import Unauthorized
-from Acquisition import aq_inner
 from design.plone.contenttypes.interfaces import IDesignPloneContenttypesLayer
 from design.plone.contenttypes.interfaces.servizio import IServizio
 from plone import api
+from plone.app.contenttypes.utils import replace_link_variables_by_paths
 from plone.dexterity.interfaces import IDexterityContent
-from plone.namedfile.interfaces import INamedFileField
+from plone.outputfilters.browser.resolveuid import uuidToURL
 from plone.restapi.interfaces import IBlockFieldSerializationTransformer
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJsonSummary
@@ -18,10 +18,12 @@ from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.schema.interfaces import IList
 from zope.schema.interfaces import ISourceText
+from zope.schema.interfaces import ITextLine
 
 import json
+import re
 
-
+RESOLVEUID_RE = re.compile(".*?/resolve[Uu]id/([^/]*)/?(.*)$")
 KEYS_WITH_URL = ["linkUrl", "navigationRoot", "showMoreLink"]
 
 
@@ -47,40 +49,6 @@ class TempiEScadenzeValueSerializer(DefaultFieldSerializer):
                 patched_timeline.append(entry)
             return json_compatible(patched_timeline)
         return value
-
-
-@adapter(INamedFileField, IDexterityContent, IDesignPloneContenttypesLayer)
-class FileFieldViewModeSerializer(DefaultFieldSerializer):
-    """Ovveride the basic DX serializer to handle the visualize file functionality"""
-
-    def __call__(self):
-        namedfile = self.field.get(self.context)
-        if namedfile is None:
-            return
-
-        url = "/".join(
-            (
-                self.context.absolute_url(),
-                self.get_file_view_mode(namedfile.contentType),
-                self.field.__name__,
-            )
-        )
-        result = {
-            "filename": namedfile.filename,
-            "content-type": namedfile.contentType,
-            "size": namedfile.getSize(),
-            "download": url,
-        }
-
-        return json_compatible(result)
-
-    def get_file_view_mode(self, content_type):
-        """Pdf view depends on the visualize_files property in thq aq_chain"""
-        if self.context and "pdf" in content_type:
-            if getattr(aq_inner(self.context), "visualize_files", None):
-                return "@@display-file"
-
-        return "@@download"
 
 
 def serialize_data(context, json_data, show_children=False):
@@ -147,3 +115,26 @@ def get_item_children(item):
         getMultiAdapter((brain, getRequest()), ISerializeToJsonSummary)()
         for brain in brains
     ]
+
+
+@adapter(ITextLine, IServizio, IDesignPloneContenttypesLayer)
+class ServizioTextLineFieldSerializer(DefaultFieldSerializer):
+    def __call__(self):
+        if self.field.getName() != "canale_digitale_link":
+            return super().__call__()
+        value = self.get_value()
+
+        path = replace_link_variables_by_paths(context=self.context, url=value)
+        match = RESOLVEUID_RE.match(path)
+        if match:
+            uid, suffix = match.groups()
+            value = uuidToURL(uid)
+        else:
+            portal = getMultiAdapter(
+                (self.context, self.context.REQUEST), name="plone_portal_state"
+            ).portal()
+            ref_obj = portal.restrictedTraverse(path, None)
+            if ref_obj:
+                value = ref_obj.absolute_url()
+
+        return json_compatible(value)

--- a/src/design/plone/contenttypes/restapi/serializers/dxfields.py
+++ b/src/design/plone/contenttypes/restapi/serializers/dxfields.py
@@ -120,9 +120,9 @@ def get_item_children(item):
 @adapter(ITextLine, IServizio, IDesignPloneContenttypesLayer)
 class ServizioTextLineFieldSerializer(DefaultFieldSerializer):
     def __call__(self):
-        if self.field.getName() != "canale_digitale_link":
-            return super().__call__()
         value = self.get_value()
+        if self.field.getName() != "canale_digitale_link" or not value:
+            return super().__call__()
 
         path = replace_link_variables_by_paths(context=self.context, url=value)
         match = RESOLVEUID_RE.match(path)

--- a/src/design/plone/contenttypes/restapi/types/adapters.py
+++ b/src/design/plone/contenttypes/restapi/types/adapters.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from collective.z3cform.datagridfield.interfaces import IRow
 from design.plone.contenttypes import _
+from design.plone.contenttypes.interfaces import IDesignPloneContenttypesLayer
 from plone.restapi.types.adapters import ObjectJsonSchemaProvider
+from redturtle.volto.types.adapters import (
+    TextLineJsonSchemaProvider as BaseTextLineJsonSchemaProvider,
+)
 from plone.restapi.types.interfaces import IJsonSchemaProvider
 from plone.restapi.types.utils import get_fieldsets
 from plone.restapi.types.utils import get_jsonschema_properties
@@ -12,8 +16,8 @@ from zope.i18n import translate
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.schema.interfaces import IField
+from zope.schema.interfaces import ITextLine
 from zope.schema.interfaces import IVocabularyFactory
-
 
 DATAGRID_FIELDS = ["value_punto_contatto", "timeline_tempi_scadenze"]
 
@@ -89,3 +93,15 @@ class DataGridRowJsonSchemaProvider(ObjectJsonSchemaProvider):
         info["required"] = required
         info["properties"] = properties
         return info
+
+
+@adapter(ITextLine, Interface, IDesignPloneContenttypesLayer)
+@implementer(IJsonSchemaProvider)
+class TextLineJsonSchemaProvider(BaseTextLineJsonSchemaProvider):
+    def get_widget(self):
+        """
+        Force url widget to some fields
+        """
+        if self.field.__name__ == "canale_digitale_link":
+            return "url"
+        return super().get_widget()

--- a/src/design/plone/contenttypes/restapi/types/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/types/configure.zcml
@@ -9,6 +9,6 @@
       name="ILeadImageBehavior.image"
       />
   <adapter factory=".adapters.DataGridRowJsonSchemaProvider" />
-
+  <adapter factory=".adapters.TextLineJsonSchemaProvider" />
 
 </configure>

--- a/test_plone60.cfg
+++ b/test_plone60.cfg
@@ -66,3 +66,9 @@ tomli = 2.0.1
 # Required by:
 # bleach==3.3.1
 webencodings = 0.5.1
+
+# Added by buildout at 2023-03-22 23:05:32.974075
+
+# Required by:
+# redturtle.prenotazioni==1.7.0.dev0
+collective.contentrules.mailfromfield = 1.1.0


### PR DESCRIPTION
Essendo un campo che deve poter essere sia un link interno che esterno, è meglio gestirlo come il campo degli oggetti Link.
In questo modo sia da Plone che da Volto è possibile usare il widget per generarli entrambi, e restapi gestisce la serializzazione/deserializzazione in maniera trasparente.

Questo è un campo nuovo o che va convertito in fase di migrazione?