### PR TITLE
Re-add FileFieldViewModeSerializer accidentally deleted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog
 6.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Re-add FileFieldViewModeSerializer accidentally deleted.
+  [cekk]
+- Fix broken tests.
+  [cekk]
 
 
 6.0.4 (2023-04-19)

--- a/src/design/plone/contenttypes/restapi/serializers/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/serializers/configure.zcml
@@ -21,6 +21,7 @@
 
   <adapter factory=".dxcontent.SerializeFolderToJson" />
   <adapter factory=".dxcontent.SerializeToJson" />
+  <adapter factory=".dxfields.FileFieldViewModeSerializer" />
   <adapter factory=".dxfields.SourceTextSerializer" />
   <adapter factory=".dxfields.TempiEScadenzeValueSerializer" />
   <adapter factory=".dxfields.ServizioTextLineFieldSerializer" />
@@ -33,4 +34,5 @@
   <adapter factory=".documento.DocumentoSerializer" />
   <adapter factory=".cartella_modulistica.CartellaModulisticaSerializer" />
   <adapter factory=".punto_di_contatto.PuntoDiContattoSerializer" />
+
 </configure>

--- a/src/design/plone/contenttypes/testing.py
+++ b/src/design/plone/contenttypes/testing.py
@@ -75,6 +75,7 @@ class DesignPloneContenttypesRestApiLayer(RedturtleVoltoRestApiLayer):
         self.loadZCML(package=plone.formwidget.geolocation)
         self.loadZCML(package=eea.api.taxonomy)
         self.loadZCML(package=collective.taxonomy)
+        self.loadZCML(package=collective.z3cform.datagridfield)
         xmlconfig.file(
             "configure.zcml",
             design.plone.contenttypes,


### PR DESCRIPTION
I don't know why i deleted it in a previous commit: https://github.com/RedTurtle/design.plone.contenttypes/commit/82165bbfc78297bf4de7ed08513ae967860df48d#diff-6e50b93b7290fe986ded61f0042da6cdc5d55a7a36701c95bbe97c7b08baa939