### PR TITLE
Add getObjSize info in File field serializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.1.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add getObjSize info in File field serializer.
+  [cekk]
 
 
 6.1.10 (2024-01-16)

--- a/src/design/plone/contenttypes/restapi/serializers/dxfields.py
+++ b/src/design/plone/contenttypes/restapi/serializers/dxfields.py
@@ -5,6 +5,7 @@ from design.plone.contenttypes.interfaces import IDesignPloneContenttypesLayer
 from design.plone.contenttypes.interfaces.servizio import IServizio
 from plone import api
 from plone.app.contenttypes.utils import replace_link_variables_by_paths
+from plone.base.utils import human_readable_size
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.interfaces import INamedFileField
 from plone.outputfilters.browser.resolveuid import uuidToURL
@@ -56,7 +57,11 @@ class TempiEScadenzeValueSerializer(DefaultFieldSerializer):
 
 @adapter(INamedFileField, IDexterityContent, IDesignPloneContenttypesLayer)
 class FileFieldViewModeSerializer(DefaultFieldSerializer):
-    """Ovveride the basic DX serializer to handle the visualize file functionality"""
+    """
+    Ovveride the basic DX serializer to:
+        - handle the visualize file functionality
+        - add getObjSize info
+    """
 
     def __call__(self):
         namedfile = self.field.get(self.context)
@@ -70,10 +75,12 @@ class FileFieldViewModeSerializer(DefaultFieldSerializer):
                 self.field.__name__,
             )
         )
+        size = namedfile.getSize()
         result = {
             "filename": namedfile.filename,
             "content-type": namedfile.contentType,
-            "size": namedfile.getSize(),
+            "size": size,
+            "getObjSize": human_readable_size(size),
             "download": url,
         }
 

--- a/src/design/plone/contenttypes/tests/test_filefield_view_mode_serializer.py
+++ b/src/design/plone/contenttypes/tests/test_filefield_view_mode_serializer.py
@@ -59,5 +59,8 @@ class SummarySerializerTest(unittest.TestCase):
         commit()
 
         response = self.api_session.get(self.modulo.absolute_url()).json()
-
         self.assertIn("@@display-file", response["file_principale"]["download"])
+
+    def test_human_readable_obj_size_in_data(self):
+        response = self.api_session.get(self.modulo.absolute_url()).json()
+        self.assertEqual("1 KB", response["file_principale"]["getObjSize"])


### PR DESCRIPTION
needed for a future feature that will show file size and meta-type in blocks, links, etc