### PR TITLE
Make footer columns auto-generation optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,10 @@ Changelog
   [eikichi18]
 - Add getObjSize info in File field serializer.
   [cekk]
-
+- Add new flag in settings needed to choose to show or not auto-generated footer columns.
+  [cekk]
+- Customize @navigation endpoint to expose also the new flag for frontend.
+  [cekk]
 
 6.1.10 (2024-01-16)
 -------------------

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - [Design Plone Content-types](#design-plone-content-types)
 - [Features](#features)
-- [Compatibilità](#compatibilit%C3%A0)
+- [Compatibilità](#compatibilità)
 - [Tipi di contenuto](#tipi-di-contenuto)
   - [Elenco tipi implementati](#elenco-tipi-implementati)
   - [Bando](#bando)
@@ -30,10 +30,11 @@
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-2)
   - [Servizio](#servizio)
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-3)
-  - [Unità Organizzativa](#unit%C3%A0-organizzativa)
+  - [Unità Organizzativa](#unità-organizzativa)
     - [Campi indicizzati nel SearchableText](#campi-indicizzati-nel-searchabletext-4)
 - [Pannello di controllo](#pannello-di-controllo)
 - [Gestione modulistica](#gestione-modulistica)
+- [Viste verifica contentuti](#viste-verifica-contentuti)
 - [Data di modifica](#data-di-modifica)
 - [Endpoint restapi](#endpoint-restapi)
   - [Customizzazione dati relation field](#customizzazione-dati-relation-field)
@@ -420,6 +421,10 @@ Endpoint ed expansion per la modulistica.
 
 Nei content-type CartellaModulistica, tra i vari expansion c'è anche `@modulistica_items`.
 Questo è utile per la vista di frontend, in quanto se richiamato, ritorna la struttura di dati da mostrare in visualizzazione.
+
+## @navigation
+
+Endpoint customizzato da plone.restapi per esporre anche il valore show_in_footer per decidere se disegnare o meno le colonne dinamiche nel footer.
 
 # Installazione
 

--- a/src/design/plone/contenttypes/controlpanels/settings.py
+++ b/src/design/plone/contenttypes/controlpanels/settings.py
@@ -88,6 +88,16 @@ class IDesignPloneSettings(Interface):
         default=True,
         required=False,
     )
+    show_dynamic_folders_in_footer = Bool(
+        title=_("show_dynamic_folders_in_footer_label", default="Footer dinamico"),
+        description=_(
+            "show_dynamic_folders_in_footer_help",
+            default="Se selezionato, il footer verrà popolato automaticamente "
+            "con i contenuti di primo livello non esclusi dalla navigazione.",
+        ),
+        default=True,
+        required=False,
+    )
 
 
 class DesignPloneControlPanelForm(RegistryEditForm):

--- a/src/design/plone/contenttypes/restapi/services/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/services/configure.zcml
@@ -6,9 +6,11 @@
 
   <include package=".content" />
   <include package=".modulistica_items" />
+  <include package=".navigation" />
   <include package=".types" />
-  <include package=".scadenziario" />
   <include package=".trasparenza" />
+  <include package=".scadenziario" />
+
 
   <adapter
       factory=".controlpanel.DesignPloneSettings"

--- a/src/design/plone/contenttypes/restapi/services/navigation/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/services/navigation/configure.zcml
@@ -1,0 +1,22 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:cache="http://namespaces.zope.org/cache"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    >
+
+  <adapter
+      factory=".get.Navigation"
+      name="navigation"
+      />
+
+  <plone:service
+      method="GET"
+      factory=".get.NavigationGet"
+      for="zope.interface.Interface"
+      permission="zope2.View"
+      name="@navigation"
+      layer="design.plone.contenttypes.interfaces.IDesignPloneContenttypesLayer"
+      />
+
+</configure>

--- a/src/design/plone/contenttypes/restapi/services/navigation/configure.zcml
+++ b/src/design/plone/contenttypes/restapi/services/navigation/configure.zcml
@@ -15,8 +15,8 @@
       factory=".get.NavigationGet"
       for="zope.interface.Interface"
       permission="zope2.View"
-      name="@navigation"
       layer="design.plone.contenttypes.interfaces.IDesignPloneContenttypesLayer"
+      name="@navigation"
       />
 
 </configure>

--- a/src/design/plone/contenttypes/restapi/services/navigation/get.py
+++ b/src/design/plone/contenttypes/restapi/services/navigation/get.py
@@ -1,0 +1,29 @@
+from design.plone.contenttypes.controlpanels.settings import IDesignPloneSettings
+from design.plone.contenttypes.interfaces import IDesignPloneContenttypesLayer
+from plone import api
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.services import Service
+from plone.restapi.services.navigation.get import Navigation as BaseNavigation
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IExpandableElement)
+@adapter(Interface, IDesignPloneContenttypesLayer)
+class Navigation(BaseNavigation):
+    def __call__(self, expand=False):
+        result = super().__call__(expand=expand)
+        show_dynamic_folders_in_footer = api.portal.get_registry_record(
+            "show_dynamic_folders_in_footer",
+            interface=IDesignPloneSettings,
+            default=False,
+        )
+        result["navigation"]["show_in_footer"] = show_dynamic_folders_in_footer
+        return result
+
+
+class NavigationGet(Service):
+    def reply(self):
+        navigation = Navigation(self.context, self.request)
+        return navigation(expand=True)["navigation"]

--- a/src/design/plone/contenttypes/tests/test_custom_service_navigation.py
+++ b/src/design/plone/contenttypes/tests/test_custom_service_navigation.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+from design.plone.contenttypes.controlpanels.settings import IDesignPloneSettings
+from design.plone.contenttypes.testing import (
+    DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING,
+)
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.dexterity.utils import createContentInContainer
+from plone.restapi.testing import RelativeSession
+from transaction import commit
+
+import unittest
+
+
+class CustomNavigationTest(unittest.TestCase):
+    layer = DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({"Accept": "application/json"})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.folder = createContentInContainer(
+            self.portal, "Folder", id="folder", title="Some Folder"
+        )
+        self.folder2 = createContentInContainer(
+            self.portal, "Folder", id="folder2", title="Some Folder 2"
+        )
+        self.subfolder1 = createContentInContainer(
+            self.folder, "Folder", id="subfolder1", title="SubFolder 1"
+        )
+        self.subfolder2 = createContentInContainer(
+            self.folder, "Folder", id="subfolder2", title="SubFolder 2"
+        )
+        self.thirdlevelfolder = createContentInContainer(
+            self.subfolder1,
+            "Folder",
+            id="thirdlevelfolder",
+            title="Third Level Folder",
+        )
+        self.fourthlevelfolder = createContentInContainer(
+            self.thirdlevelfolder,
+            "Folder",
+            id="fourthlevelfolder",
+            title="Fourth Level Folder",
+        )
+        createContentInContainer(self.folder, "Document", id="doc1", title="A document")
+        commit()
+
+    def tearDown(self):
+        self.api_session.close()
+
+    def test_return_show_in_footer_info_based_on_registry(self):
+        # by default is True
+        response = self.api_session.get(
+            "/@navigation", params={"expand.navigation.depth": 2}
+        ).json()
+
+        self.assertIn("show_in_footer", response)
+        self.assertTrue(response["show_in_footer"])
+
+        # change it
+        api.portal.set_registry_record(
+            "show_dynamic_folders_in_footer",
+            False,
+            interface=IDesignPloneSettings,
+        )
+        commit()
+
+        response = self.api_session.get(
+            "/@navigation", params={"expand.navigation.depth": 2}
+        ).json()
+
+        self.assertIn("show_in_footer", response)
+        self.assertFalse(response["show_in_footer"])

--- a/src/design/plone/contenttypes/upgrades/configure.zcml
+++ b/src/design/plone/contenttypes/upgrades/configure.zcml
@@ -804,5 +804,14 @@
         handler=".upgrades.update_pdc_with_pdc_desc"
         />
   </genericsetup:upgradeSteps>
-
+  <genericsetup:upgradeSteps
+      profile="design.plone.contenttypes:default"
+      source="7023"
+      destination="7030"
+      >
+    <genericsetup:upgradeStep
+        title="Add new field in settings"
+        handler=".upgrades.update_registry"
+        />
+  </genericsetup:upgradeSteps>
 </configure>


### PR DESCRIPTION
Add new flag in settings needed to choose to show or not auto-generated footer columns and Customize @navigation endpoint to expose also the new flag for frontend