### PR TITLE
Rimosso commit in upgrade-step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.1.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove un-needed commit in upgrade-step.
+  [cekk]
 
 
 6.1.11 (2024-01-29)

--- a/src/design/plone/contenttypes/upgrades/upgrades.py
+++ b/src/design/plone/contenttypes/upgrades/upgrades.py
@@ -1576,8 +1576,6 @@ def update_pdc_with_pdc_desc(context):
                     logger.info(f"Set pdc_desc for {pdc.absolute_url()}")
 
             pdc.value_punto_contatto = value_punto_contatto
-
-    commit()
     logger.info("Ends of update")
 
 


### PR DESCRIPTION
Fare un commit dentro alla fine di un upgrade-step non serve a niente perché tanto poi viene fatto alla chiusura della request.

Anzi, può potenzialmente portare ad uno stato inconsistente se tra questo e il commit della request c'è un problema/rollback