### PR TITLE
fix change_news_type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,17 @@ Changelog
 6.2.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix change_news_type view; Taxonomy doesn't index values not present in
+  the taxonomy vocabulary, so we had lot of old values not indexed and not listed
+  as available type to change.
+  [lucabel]
 
 
 6.2.5 (2024-04-17)
 ------------------
 
 - check-servizi: fixed check on relation title.
-  [daniele] 
+  [daniele]
 
 
 6.2.4 (2024-04-16)

--- a/src/design/plone/contenttypes/browser/utils/templates/utils.pt
+++ b/src/design/plone/contenttypes/browser/utils/templates/utils.pt
@@ -22,7 +22,7 @@
         <h3>Content-types</h3>
         <ul class="list-group">
           <li class="list-group-item">
-            <a href="${context/portal_url}/change-news-type">Cambia la Tipologia Notizia</a>
+            <a href="${context/portal_url}/change_news_type">Cambia la Tipologia Notizia</a>
             <p class="discreet">
               Questo tool viene usato per cambiare il valore del campo 'Tipologia Notizia' in tutte le notizie che hanno il valore del campo selezionato. Fa anche il giro su tutti i blocchi elenco.
             </p>

--- a/src/design/plone/contenttypes/tests/test_change_news_type.py
+++ b/src/design/plone/contenttypes/tests/test_change_news_type.py
@@ -31,13 +31,13 @@ class MoveNewsItemView(unittest.TestCase):
         self.news_item = api.content.create(
             type="News Item",
             title="news item",
-            tipologia_notizia=["notizia"],
+            tipologia_notizia="notizia",
             container=self.portal,
         )
         self.news_item1 = api.content.create(
             type="News Item",
             title="news item1",
-            tipologia_notizia=["notizia"],
+            tipologia_notizia="notizia",
             container=self.news_container,
         )
 

--- a/test_plone60.cfg
+++ b/test_plone60.cfg
@@ -60,3 +60,11 @@ tomli = 2.0.1
 webencodings = 0.5.1
 
 # Added by buildout at 2023-03-22 23:05:32.974075
+
+# Added by buildout at 2024-04-19 12:51:02.457936
+
+# Required by:
+# Plone==6.0.10
+# collective.volto.blocksfield==2.0.0
+# redturtle.bandi==1.4.3
+plone.restapi = 9.6.0


### PR DESCRIPTION
dal momento in cui si utilizza collective.taxonomy, i valori vengono indicizzati solo se sono all'interno del vocabolario della tassonomia. in questo caso tipologia_notizia.

Il che significa che change_news_types non presenta tutti i valori possibili perchè non sono a catalogo.
Il che significa che l'unico modo per far funzionare questa vista è prendere i valori delle tipologie dall'oggetto news.
e poi iterare sugli oggetti news per fare la modifica.

@folix-01 chiedo a te giusto perché conosci bene la vista