### PR TITLE
Add date to events in items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 6.2.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add start metadata to event summary serialization;
+  useful when create event with children event: in items list we
+  have subevents with missing start date
+  [lucabel]
 
 
 6.2.7 (2024-04-22)

--- a/src/design/plone/contenttypes/restapi/serializers/summary.py
+++ b/src/design/plone/contenttypes/restapi/serializers/summary.py
@@ -158,6 +158,8 @@ class DefaultJSONSummarySerializer(BaseSerializer):
                 res["tipologia_bando"] = getattr(self.context, "tipologia_bando", "")
             if "bando_state" in metadata_fields or self.show_all_metadata_fields:
                 res["bando_state"] = self.get_bando_state()
+        if self.context.portal_type == "Event":
+            res["start"] = json_compatible(self.context.start)
 
         if "geolocation" in metadata_fields or self.show_all_metadata_fields:
             # backward compatibility for some block templates

--- a/src/design/plone/contenttypes/tests/test_summary_serializer.py
+++ b/src/design/plone/contenttypes/tests/test_summary_serializer.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime 
 from design.plone.contenttypes.testing import (
     DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING,
 )
@@ -329,3 +330,25 @@ class SummarySerializerTest(unittest.TestCase):
 
         self.assertEqual(len(items), 1)
         self.assertNotIn("tipologia_bando", bando.tipologia_bando)
+
+
+    def test_event_summary(self):
+        event1 = api.content.create(
+            container=self.portal,
+            type="Event",
+            title="Evento1",
+            start=datetime(2024, 4, 22, 12, 0),
+            end=datetime(2024, 5, 22, 13, 0)
+        )
+        event2 = api.content.create(
+            container=event1,
+            type="Event",
+            title="Evento2",
+            start=datetime(2024, 4, 23, 12, 0),
+            end=datetime(2024, 4, 23, 13, 0)
+        )
+        commit()
+        resp = self.api_session.get(event1.absolute_url()).json()
+        subevent = [x for x in resp["items"] if x["@type"] == 'Event'][0]
+        self.assertIn("start", subevent)
+

--- a/src/design/plone/contenttypes/tests/test_summary_serializer.py
+++ b/src/design/plone/contenttypes/tests/test_summary_serializer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime 
+from datetime import datetime
 from design.plone.contenttypes.testing import (
     DESIGN_PLONE_CONTENTTYPES_API_FUNCTIONAL_TESTING,
 )
@@ -331,24 +331,22 @@ class SummarySerializerTest(unittest.TestCase):
         self.assertEqual(len(items), 1)
         self.assertNotIn("tipologia_bando", bando.tipologia_bando)
 
-
     def test_event_summary(self):
         event1 = api.content.create(
             container=self.portal,
             type="Event",
             title="Evento1",
             start=datetime(2024, 4, 22, 12, 0),
-            end=datetime(2024, 5, 22, 13, 0)
+            end=datetime(2024, 5, 22, 13, 0),
         )
-        event2 = api.content.create(
+        api.content.create(
             container=event1,
             type="Event",
             title="Evento2",
             start=datetime(2024, 4, 23, 12, 0),
-            end=datetime(2024, 4, 23, 13, 0)
+            end=datetime(2024, 4, 23, 13, 0),
         )
         commit()
         resp = self.api_session.get(event1.absolute_url()).json()
-        subevent = [x for x in resp["items"] if x["@type"] == 'Event'][0]
+        subevent = [x for x in resp["items"] if x["@type"] == "Event"][0]
         self.assertIn("start", subevent)
-


### PR DESCRIPTION
quando si crea un evento rassegna con eventi figli, i figli non hanno data di inizio.
si decide di partire con la start date nel summary