### PR TITLE
split news behaviors

### DIFF
--- a/src/design/plone/contenttypes/behaviors/configure.zcml
+++ b/src/design/plone/contenttypes/behaviors/configure.zcml
@@ -39,6 +39,14 @@
       />
 
   <plone:behavior
+      name="design.plone.contenttypes.behavior.news_base"
+      title="Metadati news base (senza descrizione_estesa)"
+      description="Adds fields."
+      provides=".news_additional_fields.INewsAdditionalFieldsBase"
+      marker=".news_additional_fields.INewsAdditionalFieldsBase"
+      />
+
+  <plone:behavior
       name="design.plone.contenttypes.behavior.argomenti"
       title="Argomenti"
       description="Tassonomia argomenti"

--- a/src/design/plone/contenttypes/behaviors/news_additional_fields.py
+++ b/src/design/plone/contenttypes/behaviors/news_additional_fields.py
@@ -16,16 +16,7 @@ from zope.interface import provider
 
 
 @provider(IFormFieldProvider)
-class INewsAdditionalFields(model.Schema):
-    descrizione_estesa = BlocksField(
-        title=_("descrizione_estesa", default="Descrizione estesa"),
-        required=True,
-        description=_(
-            "descrizione_estesa_help",
-            default="Descrizione dettagliata e completa.",
-        ),
-    )
-
+class INewsAdditionalFieldsBase(model.Schema):
     numero_progressivo_cs = schema.TextLine(
         title=_(
             "numero_progressivo_cs_label",
@@ -121,10 +112,22 @@ class INewsAdditionalFields(model.Schema):
         fields=["notizie_correlate"],
     )
     # custom fieldsets and order
-    form.order_before(descrizione_estesa="ILeadImageBehavior.image")
     form.order_before(numero_progressivo_cs="ILeadImageBehavior.image")
     form.order_before(a_cura_di="ILeadImageBehavior.image")
 
+
+@provider(IFormFieldProvider)
+class INewsAdditionalFields(INewsAdditionalFieldsBase):
+    descrizione_estesa = BlocksField(
+        title=_("descrizione_estesa", default="Descrizione estesa"),
+        required=True,
+        description=_(
+            "descrizione_estesa_help",
+            default="Descrizione dettagliata e completa.",
+        ),
+    )
+
+    form.order_before(descrizione_estesa="ILeadImageBehavior.image")
     textindexer.searchable("descrizione_estesa")
 
 


### PR DESCRIPTION
definito un behavior con i metadati della news, ma senza la "descrizione estesa" (blocchi).

utile ad esempio per integrare re.ufficostampa con i metadati della notizia iocomune.

il comportamento base del prodotto non dovrebbe cambiare, anche lordine dei campi dovrebbe essere preservato, visto che il campo aggiuntivo e ordinato esplicitamente