### PR TITLE
update canale_digitale_link serializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,12 @@ Changelog
 6.2.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- On CT Servizio don't want to see 'unauthorized' for anonymous user when click on
+  "Accedi al servzio" but prefer to see an 'access' label, which can be obtained using
+  {url}/login. For this reason, we want to ensure that if the current user doesn't have
+  permission to view the target of the 'access the service' button, a link with /login
+  will be used instead.
+  [lucabel]
 
 6.2.15 (2024-09-04)
 -------------------
@@ -16,7 +20,7 @@ Changelog
   [mamico]
 - Add "Emolumenti a carico della finanza pubblica" to Persona
   Add "Dichiarazioni di insussistenza e incompatibilità" to Persona
-  [lucabel]  
+  [lucabel]
 
 6.2.14 (2024-07-11)
 -------------------

--- a/src/design/plone/contenttypes/restapi/serializers/dxfields.py
+++ b/src/design/plone/contenttypes/restapi/serializers/dxfields.py
@@ -198,6 +198,9 @@ class ServizioTextLineFieldSerializer(DefaultFieldSerializer):
         match = RESOLVEUID_RE.match(path)
         if match:
             uid, suffix = match.groups()
+            # We made this check 'cause DTD asks to avoid an unauthorized page,
+            # just for the "unauthorized" label on it. If the user is anonymous,
+            # we redirect him to the login page; /login has a more friendly message
             if api.user.is_anonymous():
                 target = uuidToObject(uid, unrestricted=True)
                 value = target.absolute_url()

--- a/src/design/plone/contenttypes/tests/test_ct_servizio.py
+++ b/src/design/plone/contenttypes/tests/test_ct_servizio.py
@@ -354,8 +354,12 @@ class TestServizioApi(unittest.TestCase):
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
+        self.api_session_anon = RelativeSession(self.portal_url)
+        self.api_session_anon.headers.update({"Accept": "application/json"})
+
     def tearDown(self):
         self.api_session.close()
+        self.api_session_anon.close()
 
     def test_related_widgets(self):
         response = self.api_session.get("/@types/Servizio")
@@ -482,10 +486,14 @@ class TestServizioApi(unittest.TestCase):
             title="Test servizio",
             canale_digitale_link="/plone/resolveuid/{}".format(page.UID()),
         )
-
+        api.content.transition(obj=servizio, transition="publish")
         commit()
+
         res = self.api_session.get(servizio.absolute_url()).json()
         self.assertEqual(res["canale_digitale_link"], page.absolute_url())
+
+        res = self.api_session_anon.get(servizio.absolute_url()).json()
+        self.assertEqual(res["canale_digitale_link"], page.absolute_url() + "/login")
 
     def test_canale_digitale_link_deserialized_as_plone_internal_url(self):
         page = api.content.create(


### PR DESCRIPTION
DTD is asking to change the behavior when the 'access the service' button is pressed. They don't want to see 'unauthorized,' but rather they want an 'access' label, which can be obtained using /login. For this reason, we want to ensure that if the current user doesn't have permission to view the target of the 'access the service' button, a link with /login will be used instead.