### PR TITLE
fix dxfields serializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 6.2.19 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix a bug introduced by changes in 6.2.16
+  AttributeError: 'NoneType' object has no attribute 'absolute_url'
+  [mamico]
 
 
 6.2.18 (2024-09-06)
@@ -25,7 +27,7 @@ Changelog
 -------------------
 
 - On CT Servizio don't want to see 'unauthorized' for anonymous user when click on
-  "Accedi al servzio" but prefer to see an 'access' label, which can be obtained using
+  "Accedi al servizio" but prefer to see an 'access' label, which can be obtained using
   {url}/login. For this reason, we want to ensure that if the current user doesn't have
   permission to view the target of the 'access the service' button, a link with /login
   will be used instead.

--- a/src/design/plone/contenttypes/restapi/serializers/dxfields.py
+++ b/src/design/plone/contenttypes/restapi/serializers/dxfields.py
@@ -207,15 +207,18 @@ class ServizioTextLineFieldSerializer(DefaultFieldSerializer):
             # we redirect him to the login page; /login has a more friendly message
             if api.user.is_anonymous():
                 target = uuidToObject(uid, unrestricted=True)
-                value = target.absolute_url()
-                if (
-                    self.CHECK_CONTENT_TYPE
-                    and target.portal_type != self.CHECK_CONTENT_TYPE
-                ):
-                    return json_compatible(value)
+                if target:
+                    value = target.absolute_url()
+                    if (
+                        self.CHECK_CONTENT_TYPE
+                        and target.portal_type != self.CHECK_CONTENT_TYPE
+                    ):
+                        return json_compatible(value)
 
-                if not api.user.has_permission(self.PERMISSION_TO_CHECK, obj=target):
-                    value = f"{value}/login"
+                    if not api.user.has_permission(self.PERMISSION_TO_CHECK, obj=target):
+                        value = f"{value}/login"
+                else:
+                    value = uuidToURL(uid)
             else:
                 value = uuidToURL(uid)
         else:


### PR DESCRIPTION
if the uuid does not find an object, the code raises an exception

```
  Module plone.restapi.serializer.dxcontent, line 132, in __call__
  Module design.plone.contenttypes.restapi.serializers.dxfields, line 210, in __call__
AttributeError: 'NoneType' object has no attribute 'absolute_url'
```