### PR TITLE
Backport of #268 on v5.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 5.1.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Backport of #268: Set `file_principale` field as primary, so we call @@download on the content, that file will be downloaded automatically.
+  [cekk]
 
 
 5.1.14 (2024-09-06)

--- a/src/design/plone/contenttypes/behaviors/multi_file.py
+++ b/src/design/plone/contenttypes/behaviors/multi_file.py
@@ -40,6 +40,8 @@ class IMultiFileSchema(model.Schema):
         required=False,
     )
 
+    model.primary("file_principale")
+
 
 @provider(IFormFieldProvider)
 class IMultiFile(IMultiFileSchema):


### PR DESCRIPTION
Set  field as primary, so we call @@download on the content, that file will be downloaded automatically.