### PR TITLE
Avoid acquisition problem in *onModify* event handler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 6.2.20 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Avoid acquisition problem in *onModify* event handler: now try to reindex children only if context is folderish.
+  [cekk]
 
 6.2.19 (2024-09-23)
 -------------------

--- a/src/design/plone/contenttypes/events/common.py
+++ b/src/design/plone/contenttypes/events/common.py
@@ -199,8 +199,12 @@ def onModify(context, event):
         if "IBasic.title" in getattr(
             description, "attributes", []
         ) or "IDublinCore.title" in getattr(description, "attributes", []):
-            for child in context.listFolderContents():
-                child.reindexObject(idxs=["parent"])
+            context_state = api.content.get_view(
+                name="plone_context_state", context=context, request=context.REQUEST
+            )
+            if context_state.is_folderish():
+                for child in context.listFolderContents():
+                    child.reindexObject(idxs=["parent"])
 
 
 def createSubfolders(context, event):


### PR DESCRIPTION
now try to reindex children only if context is folderish 🤦‍♂️
