### PR TITLE
Us64414 uploda file in CT Documento

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
   [mamico]
 - Change number of related assessore_riferimento
   [lucabel]
+- Add File to CT Documento but hide it from volto add menu
+  [lucabel]
+  
 
 
 6.3.3 (2025-02-20)

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ E' presente una customizzazione del serializer per poter mostrare di default pi�
 
 Se si prova a fare un caricamento massivo di file dalla vista "*contents*" di un Documento, c'è una personalizzazione di restapi che converte il tipo da File (il default che imposta Volto per la POST) a **Modulo**. In questo modo si può fare il caricamento massivo di Moduli dentro ad un Documento.
 
+Se si prova a tagliare/incollare dei file dentro al CT Documento la cosa funziona. In realtà anche il tipo File è aggiungibile ma serve solo redazionalmente; questo significa che il File viene nascosto tramite serializer per non mostrarlo nel menu add di frontend
+
 ### Campi indicizzati nel SearchableText
 
 - blocchi Volto

--- a/src/design/plone/contenttypes/profiles/default/metadata.xml
+++ b/src/design/plone/contenttypes/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>7310</version>
+  <version>7311</version>
   <dependencies>
     <dependency>profile-redturtle.bandi:default</dependency>
     <dependency>profile-collective.venue:default</dependency>

--- a/src/design/plone/contenttypes/profiles/default/types/Documento.xml
+++ b/src/design/plone/contenttypes/profiles/default/types/Documento.xml
@@ -24,6 +24,7 @@
   <property name="allowed_content_types">
     <element value="Document" />
     <element value="Modulo" />
+    <element value="File" />
     <element value="Link" />
   </property>
   <!-- Schema, class and security -->

--- a/src/design/plone/contenttypes/restapi/serializers/documento.py
+++ b/src/design/plone/contenttypes/restapi/serializers/documento.py
@@ -64,4 +64,12 @@ class DocumentoSerializer(SerializeFolderToJson):
                 getMultiAdapter((modulo, self.request), ISerializeToJson)()
             )
         result["servizi_collegati"] = self.get_services()
+
+        types = result["@components"]["types"]
+        # if we don't have expand in request we don't have a list but this:
+        if isinstance(types, list):
+            for cttype in result["@components"]["types"]:
+                if cttype["id"] == "File":
+                    cttype["addable"] = False
+                    cttype["immediately_addable"] = False
         return result

--- a/src/design/plone/contenttypes/tests/test_ct_documento.py
+++ b/src/design/plone/contenttypes/tests/test_ct_documento.py
@@ -67,7 +67,7 @@ class TestDocumentoSchema(unittest.TestCase):
     def test_documento_addable_types(self):
         portal_types = api.portal.get_tool(name="portal_types")
         self.assertEqual(
-            ("Document", "Modulo", "Link"),
+            ("Document", "Modulo", "File", "Link"),
             portal_types["Documento"].allowed_content_types,
         )
 
@@ -340,3 +340,15 @@ class TestDocumentoApi(unittest.TestCase):
         self.assertEqual(resp.status_code, 204)
         self.assertEqual(self.documento, self.portal.listFolderContents()[1])
         self.assertEqual(new_documento, self.portal.listFolderContents()[0])
+
+    def test_document_serializer(self):
+        response = self.api_session.get(self.documento.absolute_url() + "?expand=types")
+        res = response.json()
+        for cttype in res["@components"]["types"]:
+            if cttype["id"] == "File":
+                self.assertFalse(cttype["addable"])
+                self.assertFalse(cttype["immediately_addable"])
+        documento_ct = self.portal.portal_types["Documento"]
+        self.assertEqual(
+            documento_ct.allowed_content_types, ("Document", "Modulo", "File", "Link")
+        )

--- a/src/design/plone/contenttypes/upgrades/configure.zcml
+++ b/src/design/plone/contenttypes/upgrades/configure.zcml
@@ -928,7 +928,7 @@
       handler=".to_730x.to_7310"
       />
   <genericsetup:upgradeStep
-      title="add kitconcept.seo to File"
+      title="Reload types information"
       profile="design.plone.contenttypes:default"
       source="7310"
       destination="7311"

--- a/src/design/plone/contenttypes/upgrades/configure.zcml
+++ b/src/design/plone/contenttypes/upgrades/configure.zcml
@@ -927,4 +927,11 @@
       destination="7310"
       handler=".to_730x.to_7310"
       />
+  <genericsetup:upgradeStep
+      title="add kitconcept.seo to File"
+      profile="design.plone.contenttypes:default"
+      source="7310"
+      destination="7311"
+      handler=".to_730x.to_7311"
+      />
 </configure>

--- a/src/design/plone/contenttypes/upgrades/to_730x.py
+++ b/src/design/plone/contenttypes/upgrades/to_730x.py
@@ -183,3 +183,8 @@ def to_7310(context):
             if behavior not in behaviors:
                 behaviors.append(behavior)
                 portal_type.behaviors = tuple(behaviors)
+
+
+def to_7311(context):
+    update_types(context)
+    logger.info("Update ct documento addables")


### PR DESCRIPTION
Gli editor hanno necessità di poter tagliare / incollare contenuti all'interno del ct documento.
Si vuole cambiare le cose il meno possibile rispetto alla situazione attuale per cui aggiungo il file ma lo nascondo nel menu aggiungi del frontend