### PR TITLE
Add upgrade-step to add missing metadata for image captions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add upgrade-step to add missing metadata for image captions.
+  [cekk]
 
 
 6.3.4 (2025-03-07)

--- a/src/design/plone/contenttypes/profiles/default/metadata.xml
+++ b/src/design/plone/contenttypes/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>7311</version>
+  <version>7312</version>
   <dependencies>
     <dependency>profile-redturtle.bandi:default</dependency>
     <dependency>profile-collective.venue:default</dependency>

--- a/src/design/plone/contenttypes/upgrades/configure.zcml
+++ b/src/design/plone/contenttypes/upgrades/configure.zcml
@@ -934,4 +934,11 @@
       destination="7311"
       handler=".to_730x.to_7311"
       />
+  <genericsetup:upgradeStep
+      title="Add caption metadata"
+      profile="design.plone.contenttypes:default"
+      source="7311"
+      destination="7312"
+      handler=".to_730x.to_7312"
+      />
 </configure>

--- a/src/design/plone/contenttypes/upgrades/to_730x.py
+++ b/src/design/plone/contenttypes/upgrades/to_730x.py
@@ -188,3 +188,13 @@ def to_7310(context):
 def to_7311(context):
     update_types(context)
     logger.info("Update ct documento addables")
+
+
+def to_7312(context):
+    """
+    Only add metadata if missing. We don't want to force reindexing.
+    """
+    pc = api.portal.get_tool(name="portal_catalog")
+    for column in ["image_caption", "preview_caption"]:
+        if column not in pc.schema():
+            pc.addColumn(column)


### PR DESCRIPTION
otherwise these are available only for new sites