### PR TITLE
Us64153 fine effettiva

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
   [lucabel]
 - Add upgrade-step to add missing metadata for image captions.
   [cekk]
+- Add "data fine effettiva" for events, to order listing correctly
+  [lucabel]
 
 
 6.3.4 (2025-03-07)

--- a/src/design/plone/contenttypes/configure.zcml
+++ b/src/design/plone/contenttypes/configure.zcml
@@ -72,6 +72,15 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       directory="profiles/remove_eea_api_taxonomy"
       />
+
+  <genericsetup:registerProfile
+      name="to_7313"
+      title="Design Plone: Content-types to 7313"
+      description="Fix control panel of design.plone.contenttypes add-on."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/to_7313"
+      />
+
   <utility
       factory=".setuphandlers.HiddenProfiles"
       name="design.plone.contenttypes-hiddenprofiles"

--- a/src/design/plone/contenttypes/indexers/configure.zcml
+++ b/src/design/plone/contenttypes/indexers/configure.zcml
@@ -9,6 +9,10 @@
       name="effectivestart"
       />
   <adapter
+      factory=".events.effectiveend"
+      name="effectiveend"
+      />
+  <adapter
       factory=".pagina_argomento.SearchableTextExtender"
       name="IPaginaArgomento"
       />

--- a/src/design/plone/contenttypes/indexers/events.py
+++ b/src/design/plone/contenttypes/indexers/events.py
@@ -2,6 +2,7 @@
 from plone.app.contenttypes.interfaces import IEvent
 from plone.indexer.decorator import indexer
 from plone.event.interfaces import IEventAccessor
+from plone.event.interfaces import IRecurrenceSupport
 
 
 @indexer(IEvent)
@@ -26,3 +27,15 @@ def effectivestart(obj):
     if not start:
         raise AttributeError
     return start
+
+
+@indexer(IEvent)
+def effectiveend(obj):
+    occurrences = IRecurrenceSupport(obj).occurrences()
+    end = obj.end
+    for occurrence in list(occurrences):
+        if occurrence.end > end:
+            end = occurrence.end
+    if obj.title:
+        print(f"{obj.title} - {end}")
+    return end

--- a/src/design/plone/contenttypes/profiles/default/metadata.xml
+++ b/src/design/plone/contenttypes/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>7312</version>
+  <version>7313</version>
   <dependencies>
     <dependency>profile-redturtle.bandi:default</dependency>
     <dependency>profile-collective.venue:default</dependency>

--- a/src/design/plone/contenttypes/profiles/default/registry/criteria.xml
+++ b/src/design/plone/contenttypes/profiles/default/registry/criteria.xml
@@ -588,5 +588,24 @@
     </value>
     <value i18n:translate="" i18n:domain="plone" key="group">Dates</value>
   </records>
-
+  <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.effectiveend">
+    <value key="title" i18n:translate="effectivestart">Data effettiva di fine evento</value>
+    <value key="description">Criterio per ricerche che si basano sulla data effettiva di fine</value>
+    <value key="enabled">True</value>
+    <value key="sortable">True</value>
+    <value key="operations">
+        <element>plone.app.querystring.operation.date.lessThan</element>
+        <element>plone.app.querystring.operation.date.largerThan</element>
+        <element>plone.app.querystring.operation.date.between</element>
+        <element>plone.app.querystring.operation.date.lessThanRelativeDate</element>
+        <element>plone.app.querystring.operation.date.largerThanRelativeDate</element>
+        <element>plone.app.querystring.operation.date.today</element>
+        <element>plone.app.querystring.operation.date.beforeToday</element>
+        <element>plone.app.querystring.operation.date.afterToday</element>
+        <element>plone.app.querystring.operation.date.beforeRelativeDate</element>
+        <element>plone.app.querystring.operation.date.afterRelativeDate</element>
+    </value>
+    <value i18n:translate="" i18n:domain="plone" key="group">Dates</value>
+  </records>
 </registry>

--- a/src/design/plone/contenttypes/profiles/to_7313/registry.xml
+++ b/src/design/plone/contenttypes/profiles/to_7313/registry.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone"
+>
+  <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.effectiveend" >
+    <value key="title" i18n:translate="effectivestart">Data effettiva di fine evento</value>
+    <value key="description">Criterio per ricerche che si basano sulla data effettiva di fine</value>
+    <value key="enabled">True</value>
+    <value key="sortable">True</value>
+    <value key="operations">
+        <element>plone.app.querystring.operation.date.lessThan</element>
+        <element>plone.app.querystring.operation.date.largerThan</element>
+        <element>plone.app.querystring.operation.date.between</element>
+        <element>plone.app.querystring.operation.date.lessThanRelativeDate</element>
+        <element>plone.app.querystring.operation.date.largerThanRelativeDate</element>
+        <element>plone.app.querystring.operation.date.today</element>
+        <element>plone.app.querystring.operation.date.beforeToday</element>
+        <element>plone.app.querystring.operation.date.afterToday</element>
+        <element>plone.app.querystring.operation.date.beforeRelativeDate</element>
+        <element>plone.app.querystring.operation.date.afterRelativeDate</element>
+    </value>
+    <value i18n:translate="" i18n:domain="plone" key="group">Dates</value>
+  </records>
+</registry>

--- a/src/design/plone/contenttypes/upgrades/configure.zcml
+++ b/src/design/plone/contenttypes/upgrades/configure.zcml
@@ -941,4 +941,11 @@
       destination="7312"
       handler=".to_730x.to_7312"
       />
+  <genericsetup:upgradeStep
+      title="Add caption metadata"
+      profile="design.plone.contenttypes:default"
+      source="7312"
+      destination="7313"
+      handler=".to_730x.to_7313"
+      />
 </configure>

--- a/src/design/plone/contenttypes/upgrades/to_730x.py
+++ b/src/design/plone/contenttypes/upgrades/to_730x.py
@@ -197,3 +197,27 @@ def to_7312(context):
     for column in ["image_caption", "preview_caption"]:
         if column not in pc.schema():
             pc.addColumn(column)
+
+
+def to_7313(context):
+    logger.info("Update registry")
+    update_registry(context)
+    logger.info("Add new effectiveend (DateRecurringIndex) index")
+
+    class extra:
+        recurdef = "recurrence"
+        until = ""
+
+    name = "effectiveend"
+    catalog = api.portal.get_tool(name="portal_catalog")
+    catalog.addIndex(name, "DateRecurringIndex", extra=extra())
+    logger.info("Catalog DateRecurringIndex {} created.".format(name))
+
+    logger.info("Reindex Events")
+    pc = api.portal.get_tool(name="portal_catalog")
+    brains = pc(portal_type="Event")
+    tot = len(brains)
+    for i, brain in enumerate(brains):
+        if i % 15 == 0:
+            logger.info("Progress: {}/{}".format(i, tot))
+        brain.getObject().reindexObject(idxs=["effectiveend"])

--- a/src/design/plone/contenttypes/upgrades/to_730x.py
+++ b/src/design/plone/contenttypes/upgrades/to_730x.py
@@ -201,21 +201,24 @@ def to_7312(context):
 
 def to_7313(context):
     logger.info("Update registry")
-    update_registry(context)
-    logger.info("Add new effectiveend (DateRecurringIndex) index")
+    context.runImportStepFromProfile(
+        "profile-design.plone.contenttypes:to_7313",
+        "plone.app.registry", False)
 
+    logger.info("Add new effectiveend (DateRecurringIndex) index")
     class extra:
         recurdef = "recurrence"
         until = ""
 
     name = "effectiveend"
     catalog = api.portal.get_tool(name="portal_catalog")
-    catalog.addIndex(name, "DateRecurringIndex", extra=extra())
-    logger.info("Catalog DateRecurringIndex {} created.".format(name))
+
+    if 'effectiveend' not in catalog.indexes():
+        catalog.addIndex(name, "DateRecurringIndex", extra=extra())
+        logger.info("Catalog DateRecurringIndex {} created.".format(name))
 
     logger.info("Reindex Events")
-    pc = api.portal.get_tool(name="portal_catalog")
-    brains = pc(portal_type="Event")
+    brains = catalog(portal_type="Event")
     tot = len(brains)
     for i, brain in enumerate(brains):
         if i % 15 == 0:

--- a/src/design/plone/contenttypes/upgrades/to_730x.py
+++ b/src/design/plone/contenttypes/upgrades/to_730x.py
@@ -202,10 +202,11 @@ def to_7312(context):
 def to_7313(context):
     logger.info("Update registry")
     context.runImportStepFromProfile(
-        "profile-design.plone.contenttypes:to_7313",
-        "plone.app.registry", False)
+        "profile-design.plone.contenttypes:to_7313", "plone.app.registry", False
+    )
 
     logger.info("Add new effectiveend (DateRecurringIndex) index")
+
     class extra:
         recurdef = "recurrence"
         until = ""
@@ -213,7 +214,7 @@ def to_7313(context):
     name = "effectiveend"
     catalog = api.portal.get_tool(name="portal_catalog")
 
-    if 'effectiveend' not in catalog.indexes():
+    if "effectiveend" not in catalog.indexes():
         catalog.addIndex(name, "DateRecurringIndex", extra=extra())
         logger.info("Catalog DateRecurringIndex {} created.".format(name))
 


### PR DESCRIPTION
Aggiunto un indice "data di fine effettiva" degli eventi perchè il layer di redturtle.volto faceva cose con le date di inizio e fine evento. In questo modo calcoliamo in un indice la vera fine e possiamo ordinare per quella.
Tenendo conto anche delle ricorrenze.