### PR TITLE
Bug data apertura summary bandi

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 6.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix operator order in condition in summary for apertura_bando
+  [mamico]
 
 6.3.6 (2025-04-09)
 ------------------

--- a/src/design/plone/contenttypes/restapi/serializers/summary.py
+++ b/src/design/plone/contenttypes/restapi/serializers/summary.py
@@ -160,11 +160,9 @@ class DefaultJSONSummarySerializer(BaseSerializer):
                 res["bando_state"] = self.get_bando_state()
 
             # if default set to None
-            if (
-                ("apertura_bando" in metadata_fields or self.show_all_metadata_fields)
-                and res["apertura_bando"] == "1100-01-01T00:00:00"
-            ):
-                res["apertura_bando"] = None
+            if "apertura_bando" in metadata_fields or self.show_all_metadata_fields:
+                if res.get("apertura_bando") == "1100-01-01T00:00:00":
+                    res["apertura_bando"] = None
 
         if self.context.portal_type == "Event":
             res["start"] = json_compatible(self.context.start)

--- a/src/design/plone/contenttypes/restapi/serializers/summary.py
+++ b/src/design/plone/contenttypes/restapi/serializers/summary.py
@@ -161,8 +161,7 @@ class DefaultJSONSummarySerializer(BaseSerializer):
 
             # if default set to None
             if (
-                "apertura_bando" in metadata_fields
-                or self.show_all_metadata_fields
+                ("apertura_bando" in metadata_fields or self.show_all_metadata_fields)
                 and res["apertura_bando"] == "1100-01-01T00:00:00"
             ):
                 res["apertura_bando"] = None


### PR DESCRIPTION
La condition era sbagliata perchè and viene prima degli or, quindi ogni volta che apeertura_bando era in metadata_fields veniva azzerato.

ho prima sistemato con le giuste parentesi, poi per migliorare la lettura ho splittato su due if