### PR TITLE
Updated @scadenziario-day endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 6.3.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Now @scadenziario-day returns also a list "luoghi_correlati" and
+  "parent_event" if there is one directly above.
+  [fedevancin]
 
 
 6.3.16 (2026-04-07)

--- a/src/design/plone/contenttypes/restapi/services/scadenziario/post.py
+++ b/src/design/plone/contenttypes/restapi/services/scadenziario/post.py
@@ -85,6 +85,55 @@ class BaseService(Service):
             exp_result.reverse()
         return exp_result
 
+    def _get_image_scales(self, context):
+        """Get image scales for a content object."""
+        scales = queryMultiAdapter(
+            (context, self.request),
+            IImageScalesAdapter,
+        )
+        return scales() if scales else {}
+
+    def _get_related_places(self, event_obj):
+        """Extract related places (luoghi_correlati) from event object.
+
+        Returns a list of dicts with 'name' and 'url' keys.
+        """
+        related_places = []
+        try:
+            # Try to get the field from the behavior
+            if hasattr(event_obj, "luoghi_correlati"):
+                relations = event_obj.luoghi_correlati
+                if relations:
+                    for relation in relations:
+                        target = relation.to_object
+                        if target:
+                            related_places.append(
+                                {
+                                    "name": target.title or target.id,
+                                    "url": target.absolute_url(),
+                                }
+                            )
+        except (AttributeError, TypeError):
+            # Field doesn't exist or relation access fails
+            pass
+        return related_places
+
+    def _get_parent_event(self, event_obj):
+        """Get parent event info if this event is a child of another event.
+
+        Returns a dict with 'name' and 'url' keys, or None if no parent.
+        """
+        try:
+            parent = event_obj.aq_parent
+            if parent and parent.portal_type == "Event":
+                return {
+                    "name": parent.title or parent.id,
+                    "url": parent.absolute_url(),
+                }
+        except (AttributeError, TypeError):
+            pass
+        return None
+
 
 class ScadenziarioSearchPost(BaseService):
     """
@@ -196,10 +245,7 @@ class ScadenziarioDayPost(BaseService):
         if sort_order not in {"descending", "ascending"}:
             sort_order = "ascending"
 
-        # results = querybuilder(**querybuilder_parameters)
-        # Seems that origina querybuilder is not able to handle event search on
-        # a single day... I can handle this calling catalog and going through
-        # DateTime conversion
+        # Convert query to catalog query with DateTime objects
         query_for_catalog = queryparser.parseFormquery(
             self.context, query, sort_on=sort_on, sort_order=sort_order
         )
@@ -209,83 +255,116 @@ class ScadenziarioDayPost(BaseService):
         query_for_catalog["start"]["query"][1] = DateTime(
             query_for_catalog["start"]["query"][1]
         )
+
+        # Execute the catalog query
         results = self.context.portal_catalog(query_for_catalog)
-        # preparati per l'expand degli eventi.
+
+        # Separate events from other content types
         not_events = [x for x in results if x.portal_type != "Event"]
         events = [x for x in results if x.portal_type == "Event"]
-        start = None
-        end = None
-        # qui ce l'abbiamo per forza start
+
+        # Extract start/end dates from query
+        start = end = None
         if "start" in query_for_catalog:
             start = query_for_catalog["start"]["query"][0]
         if "end" in query_for_catalog:
             end = query_for_catalog["start"]["query"][1]
 
+        # Expand recurring events
         expanded_events = self.expand_events(events, 3, start, end)
-        start_date = start.strftime("%Y/%m/%d")
-        correct_events = []
-        for x in expanded_events:
-            if start_date == x.start.strftime("%Y/%m/%d"):
-                correct_events.append(x)
 
+        # Filter events to only those on the requested day
+        start_date = start.strftime("%Y/%m/%d")
+        correct_events = [
+            x
+            for x in expanded_events
+            if start_date == x.start.strftime("%Y/%m/%d")  # noqa: E501
+        ]
+
+        # Combine all results
         all_results = not_events + correct_events
 
+        # Group results by date
         brains_grouped = {}
         for brain in all_results:
-            if not safe_hasattr(results[0], "start"):
+            if not safe_hasattr(brain, "start") or not brain.start:
                 continue
-            brains_grouped.setdefault(brain.start.strftime("%Y/%m/%d"), []).append(
-                brain
-            )
+            date_key = brain.start.strftime("%Y/%m/%d")
+            brains_grouped.setdefault(date_key, []).append(brain)
 
-        keys = list(brains_grouped.keys())
-        keys.sort()
-
+        # Build response with enhanced data
         results_to_be_returned = {}
-        for key in keys:
-            results_to_be_returned[key] = []
-            for brain in brains_grouped[key]:
-                if isinstance(brain, (EventAccessor, EventOccurrenceAccessor)):
-                    if brain.context.portal_type == "Occurrence":
-                        url = brain.url[:-10]
-                        scales = queryMultiAdapter(
-                            (brain.context.aq_parent, self.request), IImageScalesAdapter
-                        )
-                        image_scales = scales()
-                    else:
-                        url = brain.url
-                        scales = queryMultiAdapter(
-                            (brain.context, self.request), IImageScalesAdapter
-                        )
-                        image_scales = scales()
-
-                    results_to_be_returned[key].append(
-                        {
-                            "@id": url,
-                            "id": brain.id,
-                            "title": brain.title,
-                            "text": brain.description,
-                            "start": brain.start.isoformat(),
-                            "type": self.context.translate("Event"),
-                            "category": brain.subjects,
-                            "image_scales": image_scales,
-                        }
-                    )
-
-                else:
-                    results_to_be_returned[key].append(
-                        {
-                            "@id": brain.getURL(),
-                            "id": brain.getId,
-                            "title": brain.Title,
-                            "text": brain.Description,
-                            "start": brain.start.isoformat(),
-                            "type": self.context.translate(brain.portal_type),
-                            "category": brain.subject,
-                        }
-                    )
+        for date_key in sorted(brains_grouped.keys()):
+            results_to_be_returned[date_key] = []
+            for brain in brains_grouped[date_key]:
+                item_data = self._build_item_data(brain)
+                results_to_be_returned[date_key].append(item_data)
 
         return {
             "@id": self.request.get("URL"),
             "items": results_to_be_returned,
         }
+
+    def _build_item_data(self, brain):
+        """Build the data dictionary for a single item.
+
+        Handles both EventAccessor/EventOccurrenceAccessor and brain results.
+        """
+        if isinstance(brain, (EventAccessor, EventOccurrenceAccessor)):
+            return self._build_event_accessor_item(brain)
+        else:
+            return self._build_brain_item(brain)
+
+    def _build_event_accessor_item(self, brain):
+        """Build item data from EventAccessor or EventOccurrenceAccessor."""
+        # Get the actual object based on occurrence type
+        if brain.context.portal_type == "Occurrence":
+            event_obj = brain.context.aq_parent
+            url = brain.url[:-10]  # Remove "/@@view" suffix
+        else:
+            event_obj = brain.context
+            url = brain.url
+
+        # Get image scales
+        image_scales = self._get_image_scales(event_obj)
+
+        # Build base item data
+        item_data = {
+            "@id": url,
+            "id": brain.id,
+            "title": brain.title,
+            "text": brain.description,
+            "start": brain.start.isoformat(),
+            "type": self.context.translate("Event"),
+            "category": brain.subjects,
+            "image_scales": image_scales,
+        }
+
+        # Add related places and parent event info
+        self._add_relations_data(item_data, event_obj)
+
+        return item_data
+
+    def _build_brain_item(self, brain):
+        """Build item data from a catalog brain (non-event)."""
+        return {
+            "@id": brain.getURL(),
+            "id": brain.getId,
+            "title": brain.Title,
+            "text": brain.Description,
+            "start": brain.start.isoformat(),
+            "type": self.context.translate(brain.portal_type),
+            "category": brain.subject,
+        }
+
+    def _add_relations_data(self, item_data, event_obj):
+        """Add related places and parent event info to item data."""
+        # Add related places (luoghi_correlati)
+        related_places = self._get_related_places(event_obj)
+        if related_places:
+            item_data["luoghi_correlati"] = related_places
+
+        # Add parent event info (rassegna)
+        parent_event = self._get_parent_event(event_obj)
+        if parent_event:
+            item_data["parent_event"] = parent_event

--- a/src/design/plone/contenttypes/restapi/services/scadenziario/post.py
+++ b/src/design/plone/contenttypes/restapi/services/scadenziario/post.py
@@ -249,12 +249,11 @@ class ScadenziarioDayPost(BaseService):
         query_for_catalog = queryparser.parseFormquery(
             self.context, query, sort_on=sort_on, sort_order=sort_order
         )
-        query_for_catalog["start"]["query"][0] = DateTime(
-            query_for_catalog["start"]["query"][0]
-        )
-        query_for_catalog["start"]["query"][1] = DateTime(
-            query_for_catalog["start"]["query"][1]
-        )
+
+        # Normalize date query values so they can be consumed by portal_catalog
+        # across different querystring parser versions.
+        self._normalize_query_datetime(query_for_catalog, "start")
+        self._normalize_query_datetime(query_for_catalog, "end")
 
         # Execute the catalog query
         results = self.context.portal_catalog(query_for_catalog)
@@ -266,20 +265,24 @@ class ScadenziarioDayPost(BaseService):
         # Extract start/end dates from query
         start = end = None
         if "start" in query_for_catalog:
-            start = query_for_catalog["start"]["query"][0]
+            start, end = self._extract_date_range(query_for_catalog["start"])
         if "end" in query_for_catalog:
-            end = query_for_catalog["start"]["query"][1]
+            end_from_end, _ = self._extract_date_range(query_for_catalog["end"])
+            if end_from_end and not end:
+                end = end_from_end
 
         # Expand recurring events
         expanded_events = self.expand_events(events, 3, start, end)
 
         # Filter events to only those on the requested day
-        start_date = start.strftime("%Y/%m/%d")
-        correct_events = [
-            x
-            for x in expanded_events
-            if start_date == x.start.strftime("%Y/%m/%d")  # noqa: E501
-        ]
+        correct_events = expanded_events
+        if start:
+            start_date = start.strftime("%Y/%m/%d")
+            correct_events = [
+                x
+                for x in expanded_events
+                if start_date == x.start.strftime("%Y/%m/%d")  # noqa: E501
+            ]
 
         # Combine all results
         all_results = not_events + correct_events
@@ -304,6 +307,31 @@ class ScadenziarioDayPost(BaseService):
             "@id": self.request.get("URL"),
             "items": results_to_be_returned,
         }
+
+    def _normalize_query_datetime(self, query_for_catalog, field_name):
+        field_query = query_for_catalog.get(field_name)
+        if not field_query or "query" not in field_query:
+            return
+
+        raw_query = field_query["query"]
+        if isinstance(raw_query, (list, tuple)):
+            field_query["query"] = [self._to_datetime(v) for v in raw_query]
+        else:
+            field_query["query"] = self._to_datetime(raw_query)
+
+    def _to_datetime(self, value):
+        if value is None or isinstance(value, DateTime):
+            return value
+        return DateTime(value)
+
+    def _extract_date_range(self, field_query):
+        raw_query = field_query.get("query")
+        if isinstance(raw_query, (list, tuple)):
+            if len(raw_query) >= 2:
+                return raw_query[0], raw_query[1]
+            if len(raw_query) == 1:
+                return raw_query[0], None
+        return raw_query, None
 
     def _build_item_data(self, brain):
         """Build the data dictionary for a single item.

--- a/src/design/plone/contenttypes/tests/test_service_scadenziario.py
+++ b/src/design/plone/contenttypes/tests/test_service_scadenziario.py
@@ -87,3 +87,207 @@ class ScadenziarioTest(unittest.TestCase):
             response["items"][1],
             future_event_1.start.strftime("%Y/%m/%d"),
         )
+
+    def test_scadenziario_day_returns_events_for_specific_day(self):
+        """Test @scadenziario-day endpoint returns events for a specific day."""
+        now = datetime.now()
+        target_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        # Create events on different days
+        api.content.create(
+            container=self.portal,
+            type="Event",
+            title="Event Today Morning",
+            start=target_day.replace(hour=9),
+            end=target_day.replace(hour=11),
+        )
+
+        api.content.create(
+            container=self.portal,
+            type="Event",
+            title="Event Today Afternoon",
+            start=target_day.replace(hour=14),
+            end=target_day.replace(hour=16),
+        )
+
+        api.content.create(
+            container=self.portal,
+            type="Event",
+            title="Event Tomorrow",
+            start=(target_day + timedelta(days=1)).replace(hour=9),
+            end=(target_day + timedelta(days=1)).replace(hour=11),
+        )
+
+        commit()
+
+        # Query for events on the target day
+        response = self.api_session.post(
+            f"{self.portal_url}/@scadenziario-day",
+            json={
+                "query": [
+                    {
+                        "i": "start",
+                        "o": ("plone.app.querystring.operation." "date.afterToday"),
+                        "v": "",
+                    }
+                ]
+            },
+        ).json()
+
+        date_key = target_day.strftime("%Y/%m/%d")
+        self.assertIn(date_key, response["items"])
+        self.assertEqual(len(response["items"][date_key]), 2)
+
+        titles = [item["title"] for item in response["items"][date_key]]
+        self.assertIn("Event Today Morning", titles)
+        self.assertIn("Event Today Afternoon", titles)
+
+    def test_scadenziario_day_includes_related_places(self):
+        """Test @scadenziario-day includes related places (luoghi_correlati)."""
+        from z3c.relationfield import RelationValue
+        from zope.component import getUtility
+        from zope.intid.interfaces import IIntIds
+
+        now = datetime.now()
+        target_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        # Create a venue
+        venue = api.content.create(
+            container=self.portal,
+            type="Venue",
+            title="Test Venue",
+        )
+
+        # Create event with related places
+        event = api.content.create(
+            container=self.portal,
+            type="Event",
+            title="Event with Venue",
+            start=target_day.replace(hour=9),
+            end=target_day.replace(hour=11),
+        )
+
+        # Set the related places (luoghi_correlati) using the behavior
+        intids = getUtility(IIntIds)
+        venue_id = intids.getId(venue)
+        event.luoghi_correlati = [RelationValue(venue_id)]
+
+        event.reindexObject()
+        commit()
+
+        response = self.api_session.post(
+            f"{self.portal_url}/@scadenziario-day",
+            json={
+                "query": [
+                    {
+                        "i": "start",
+                        "o": ("plone.app.querystring.operation." "date.afterToday"),
+                        "v": "",
+                    }
+                ]
+            },
+        ).json()
+
+        date_key = target_day.strftime("%Y/%m/%d")
+        event_data = response["items"][date_key][0]
+
+        # Check that luoghi_correlati is present and correct
+        self.assertIn("luoghi_correlati", event_data)
+        self.assertEqual(len(event_data["luoghi_correlati"]), 1)
+        self.assertEqual(
+            event_data["luoghi_correlati"][0]["name"],
+            "Test Venue",
+        )
+        self.assertIn(venue.id, event_data["luoghi_correlati"][0]["url"])
+
+    def test_scadenziario_day_includes_parent_event(self):
+        """Test @scadenziario-day includes parent event (rassegna) info."""
+        now = datetime.now()
+        target_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        # Create parent event (rassegna)
+        parent_event = api.content.create(
+            container=self.portal,
+            type="Event",
+            title="Rassegna Events",
+            start=target_day.replace(hour=8),
+            end=(target_day + timedelta(days=7)).replace(hour=18),
+        )
+
+        # Create child event inside parent event
+        child_event = api.content.create(
+            container=parent_event,
+            type="Event",
+            title="Child Event",
+            start=target_day.replace(hour=9),
+            end=target_day.replace(hour=11),
+        )
+
+        child_event.reindexObject()
+        parent_event.reindexObject()
+        commit()
+
+        response = self.api_session.post(
+            f"{self.portal_url}/@scadenziario-day",
+            json={
+                "query": [
+                    {
+                        "i": "start",
+                        "o": "plone.app.querystring.operation.date.afterToday",
+                        "v": "",
+                    }
+                ]
+            },
+        ).json()
+
+        date_key = target_day.strftime("%Y/%m/%d")
+        # Find the child event in the results
+        event_data = None
+        for item in response["items"].get(date_key, []):
+            if item["title"] == "Child Event":
+                event_data = item
+                break
+
+        self.assertIsNotNone(event_data)
+        # Check that parent_event is present and correct
+        self.assertIn("parent_event", event_data)
+        self.assertEqual(event_data["parent_event"]["name"], "Rassegna Events")
+        self.assertIn(parent_event.id, event_data["parent_event"]["url"])
+
+    def test_scadenziario_day_without_related_places_or_parent(self):
+        """Test @scadenziario-day event without related places or parent."""
+        now = datetime.now()
+        target_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        # Create standalone event
+        event = api.content.create(
+            container=self.portal,
+            type="Event",
+            title="Standalone Event",
+            start=target_day.replace(hour=9),
+            end=target_day.replace(hour=11),
+        )
+
+        event.reindexObject()
+        commit()
+
+        response = self.api_session.post(
+            f"{self.portal_url}/@scadenziario-day",
+            json={
+                "query": [
+                    {
+                        "i": "start",
+                        "o": "plone.app.querystring.operation.date.afterToday",
+                        "v": "",
+                    }
+                ]
+            },
+        ).json()
+
+        date_key = target_day.strftime("%Y/%m/%d")
+        event_data = response["items"][date_key][0]
+
+        # Check that luoghi_correlati and parent_event are NOT in the response
+        # (or empty if present)
+        self.assertFalse(event_data.get("luoghi_correlati"))
+        self.assertFalse(event_data.get("parent_event"))

--- a/src/design/plone/contenttypes/tests/test_service_scadenziario.py
+++ b/src/design/plone/contenttypes/tests/test_service_scadenziario.py
@@ -91,7 +91,9 @@ class ScadenziarioTest(unittest.TestCase):
     def test_scadenziario_day_returns_events_for_specific_day(self):
         """Test @scadenziario-day endpoint returns events for a specific day."""
         now = datetime.now()
-        target_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        target_day = (now + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
 
         # Create events on different days
         api.content.create(
@@ -127,8 +129,11 @@ class ScadenziarioTest(unittest.TestCase):
                 "query": [
                     {
                         "i": "start",
-                        "o": ("plone.app.querystring.operation." "date.afterToday"),
-                        "v": "",
+                        "o": "plone.app.querystring.operation.date.between",
+                        "v": [
+                            target_day.strftime("%Y-%m-%d"),
+                            (target_day + timedelta(days=1)).strftime("%Y-%m-%d"),
+                        ],
                     }
                 ]
             },
@@ -149,7 +154,9 @@ class ScadenziarioTest(unittest.TestCase):
         from zope.intid.interfaces import IIntIds
 
         now = datetime.now()
-        target_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        target_day = (now + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
 
         # Create a venue
         venue = api.content.create(
@@ -181,15 +188,24 @@ class ScadenziarioTest(unittest.TestCase):
                 "query": [
                     {
                         "i": "start",
-                        "o": ("plone.app.querystring.operation." "date.afterToday"),
-                        "v": "",
+                        "o": "plone.app.querystring.operation.date.between",
+                        "v": [
+                            target_day.strftime("%Y-%m-%d"),
+                            (target_day + timedelta(days=1)).strftime("%Y-%m-%d"),
+                        ],
                     }
                 ]
             },
         ).json()
 
         date_key = target_day.strftime("%Y/%m/%d")
-        event_data = response["items"][date_key][0]
+        event_data = None
+        for item in response["items"].get(date_key, []):
+            if item["title"] == "Event with Venue":
+                event_data = item
+                break
+
+        self.assertIsNotNone(event_data)
 
         # Check that luoghi_correlati is present and correct
         self.assertIn("luoghi_correlati", event_data)
@@ -203,7 +219,9 @@ class ScadenziarioTest(unittest.TestCase):
     def test_scadenziario_day_includes_parent_event(self):
         """Test @scadenziario-day includes parent event (rassegna) info."""
         now = datetime.now()
-        target_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        target_day = (now + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
 
         # Create parent event (rassegna)
         parent_event = api.content.create(
@@ -233,8 +251,11 @@ class ScadenziarioTest(unittest.TestCase):
                 "query": [
                     {
                         "i": "start",
-                        "o": "plone.app.querystring.operation.date.afterToday",
-                        "v": "",
+                        "o": "plone.app.querystring.operation.date.between",
+                        "v": [
+                            target_day.strftime("%Y-%m-%d"),
+                            (target_day + timedelta(days=1)).strftime("%Y-%m-%d"),
+                        ],
                     }
                 ]
             },
@@ -257,7 +278,9 @@ class ScadenziarioTest(unittest.TestCase):
     def test_scadenziario_day_without_related_places_or_parent(self):
         """Test @scadenziario-day event without related places or parent."""
         now = datetime.now()
-        target_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        target_day = (now + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
 
         # Create standalone event
         event = api.content.create(
@@ -277,15 +300,24 @@ class ScadenziarioTest(unittest.TestCase):
                 "query": [
                     {
                         "i": "start",
-                        "o": "plone.app.querystring.operation.date.afterToday",
-                        "v": "",
+                        "o": "plone.app.querystring.operation.date.between",
+                        "v": [
+                            target_day.strftime("%Y-%m-%d"),
+                            (target_day + timedelta(days=1)).strftime("%Y-%m-%d"),
+                        ],
                     }
                 ]
             },
         ).json()
 
         date_key = target_day.strftime("%Y/%m/%d")
-        event_data = response["items"][date_key][0]
+        event_data = None
+        for item in response["items"].get(date_key, []):
+            if item["title"] == "Standalone Event":
+                event_data = item
+                break
+
+        self.assertIsNotNone(event_data)
 
         # Check that luoghi_correlati and parent_event are NOT in the response
         # (or empty if present)


### PR DESCRIPTION
Now POST requests to @scadenziario-day on Event contexts return also a "luoghi-correlati" list of places.
If the event is directly inside another one, the outer one is returned in the field "parent_event".

All new information items returned are shaped as objects {name, url} for automatic link rendering in the frontend.

Some refactoring of the pre-existing code was needed in order to satisfy the linter.