### PR TITLE
fixed endpoint scadenziario-day to return preview image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Changelog
   downstream packages can add extra fields to ``@scadenziario-day`` event
   results without duplicating the whole endpoint.
   [fedevancin]
-
+- Fix ``@scadenziario-day`` endpoint to return preview image properly.
+  [daniele]
 
 6.3.16 (2026-04-07)
 -------------------

--- a/src/design/plone/contenttypes/restapi/services/scadenziario/post.py
+++ b/src/design/plone/contenttypes/restapi/services/scadenziario/post.py
@@ -319,7 +319,11 @@ class ScadenziarioDayPost(BaseService):
                         "type": self.context.translate("Event"),
                         "category": brain.subjects,
                         "image_scales": image_scales,
-                        "image": image_scales.get(image_field_name) if image_field_name else None,
+                        "image": (
+                            image_scales.get(image_field_name)
+                            if image_field_name
+                            else None
+                        ),
                         "image_field": image_field_name,
                     }
                     item.update(self._get_extra_event_data(event_obj))

--- a/src/design/plone/contenttypes/restapi/services/scadenziario/post.py
+++ b/src/design/plone/contenttypes/restapi/services/scadenziario/post.py
@@ -304,6 +304,12 @@ class ScadenziarioDayPost(BaseService):
                     )
                     image_scales = scales()
 
+                    image_field_name = None
+                    if getattr(event_obj, "preview_image", None):
+                        image_field_name = "preview_image"
+                    elif getattr(event_obj, "image", None):
+                        image_field_name = "image"
+
                     item = {
                         "@id": url,
                         "id": brain.id,
@@ -313,6 +319,8 @@ class ScadenziarioDayPost(BaseService):
                         "type": self.context.translate("Event"),
                         "category": brain.subjects,
                         "image_scales": image_scales,
+                        "image": image_scales.get(image_field_name) if image_field_name else None,
+                        "image_field": image_field_name,
                     }
                     item.update(self._get_extra_event_data(event_obj))
                     results_to_be_returned[key].append(item)


### PR DESCRIPTION
Fix @scadenziario-day endpoint to return fields "image" and "image_fields" in order to show preview image properly as standard block-listing behavior.